### PR TITLE
Address code review: concurrency fixes, API polish, extensive tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ go.work
 
 # Claude Code local tooling (per-developer permissions, run state)
 .claude/
+
+# JetBrains IDE
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@
 
 # Go workspace file
 go.work
+
+# Claude Code local tooling (per-developer permissions, run state)
+.claude/

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ returns it. Subsequent requests for the same key return the cached value.
 Here's a trivial example that caches computed fibonacci numbers:
 
 ```go
-func ExampleFibonacci() {
+func ExampleCache_Get() {
 	// Ignore error handling for brevity.
 	ctx := context.Background()
 	c := oncecache.New[int, int](calcFibonacci)

--- a/README.md
+++ b/README.md
@@ -107,11 +107,12 @@ func ExampleCache_Keys() {
 	didSet = c.MaybeSet(ctx, 7, 13, nil) // Cache write: 7 not in cache
 	fmt.Println("Did set 7?", didSet)
 
-	c.Clear(ctx) // Clear empties c, but it's still usable
+	c.Clear(ctx) // Clear empties c, firing any OnEvict callbacks.
 	fmt.Println("Keys after cache clear:", c.Keys())
 
-	// Close clears c and releases resources. Afterwards, c is unusable,
-	// and operations on it may return an error.
+	// Close empties the cache without firing OnEvict. Callbacks are
+	// retained and the cache remains fully usable for later Get /
+	// MaybeSet / Delete calls.
 	_ = c.Close()
 
 	// Output:
@@ -128,6 +129,20 @@ func ExampleCache_Keys() {
 }
 ```
 
+### Errors and panics
+
+An error returned by the fetch function is cached alongside the value: the
+entry `(key, zero-value, err)` is still a fully-populated entry, and a
+subsequent `Get` for the same key returns that same error without reinvoking
+fetch, until the entry is explicitly evicted.
+
+If the fetch function **panics**, `oncecache` recovers the panic and stores it
+as an error wrapping the exported
+[`ErrPanic`](https://pkg.go.dev/github.com/neilotoole/oncecache#ErrPanic)
+sentinel. `Get` returns that wrapped error — the panic is *not* propagated
+to the caller. `OnFill` callbacks fire normally with the wrapped error.
+Detect the case with `errors.Is(err, oncecache.ErrPanic)`.
+
 ### Callbacks
 
 When constructing a cache, you can provide callback functions that are invoked
@@ -138,6 +153,7 @@ Here's an example that logs cache events:
 
 ```go
 func main() {
+	ctx := context.Background()
 	log := slog.Default()
 	c := oncecache.New[int, int](
 		calcFibonacci,
@@ -166,10 +182,20 @@ you can use one of the (synchronous) [`OnHit`](https://pkg.go.dev/github.com/nei
 [`OnFill`](https://pkg.go.dev/github.com/neilotoole/oncecache#OnFill)
 or [`OnEvict`](https://pkg.go.dev/github.com/neilotoole/oncecache#OnEvict)
 handlers, or the more generic [`OnEvent`](https://pkg.go.dev/github.com/neilotoole/oncecache#OnEvent) handler,
-which receives cache events on a channel.
+which receives cache events on a channel. Each delivered
+[`Event`](https://pkg.go.dev/github.com/neilotoole/oncecache#Event) carries
+the triggering context as `Event.Ctx`, so async consumers can observe
+cancellation or propagate trace state.
+
+The synchronous callbacks may freely act on other keys or other caches —
+the foundation of the composite-cache propagation pattern shown below. The
+one restriction is that `OnFill` / `OnMiss` / `OnHit` must not call `Get`
+or `MaybeSet` for the *same key on the same cache* (that re-enters the
+entry's internal `sync.Once` and deadlocks). `OnEvict` has no such
+restriction.
 
 See `TestCallbacks` or `TestOnEventChan` in [`oncecache_test.go`](./oncecache_test.go) for
-more details, or the take a look at the [`hrsystem` example](./examples/hrsystem/README.md).
+more details, or take a look at the [`hrsystem` example](./examples/hrsystem/README.md).
 
 ## Cache composition & propagation
 
@@ -306,4 +332,4 @@ func (c *HRCache) onFillDept(ctx context.Context, _ string, dept *Department, er
 
 - `oncecache` was developed for use by [`sq`](https://sq.io), which uses `oncecache`
   to cache database metadata, e.g. the entire metadata of a database schema, or individual tables
-  withing that schema. See it in use [here](https://github.com/neilotoole/sq/blob/e86d01fdb756a212c59edd3bd6cbd5a5a1b3056d/libsq/source/mdcache/mdcache.go#L22).
+  within that schema. See it in use [here](https://github.com/neilotoole/sq/blob/e86d01fdb756a212c59edd3bd6cbd5a5a1b3056d/libsq/source/mdcache/mdcache.go#L22).

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ func calcFibonacci(ctx context.Context, n int) (val int, err error) {
 [`Keys`](https://pkg.go.dev/github.com/neilotoole/oncecache#Cache.Keys), etc.
 
 ```go
-func ExampleOperations() {
+func ExampleCache_Keys() {
 	// Ignore error handling for brevity.
 	ctx := context.Background()
 	c := oncecache.New[int, int](calcFibonacci)

--- a/event.go
+++ b/event.go
@@ -5,37 +5,72 @@ import (
 	"fmt"
 )
 
+// callbackFunc is the shared signature for every registered callback. The
+// ctx is decorated with the source [Cache] (retrievable via [FromContext]);
+// key is the affected key; val and err are the entry's stored value and
+// fill error. On [OpMiss], val and err are the zero value, since the entry
+// has not yet been populated at the time the miss is observed.
 type callbackFunc[K comparable, V any] func(ctx context.Context, key K, val V, err error)
 
-// Entry is the external representation of a cache entry. It is not part of the
-// cache's internal state; it can be modified by the user if desired.
+// Entry is the external (user-facing) representation of a cache entry, as
+// passed to event subscribers. It is a value type, independent of the
+// cache's internal state: modifying its fields has no effect on the cache.
+//
+// An [Entry] is typically observed via an [Event] delivered to an [OnEvent]
+// channel, or constructed by one of the package's logging helpers. Callers
+// rarely construct Entry values directly.
 type Entry[K comparable, V any] struct {
+	// Cache is the source cache that produced this entry. It is set for
+	// every entry emitted by this package.
 	Cache *Cache[K, V]
-	Key   K
-	Val   V
-	Err   error
+
+	// Key is the cache key this entry corresponds to.
+	Key K
+
+	// Val is the stored value. On an [OpMiss] event, Val is the zero value
+	// of V because the miss is observed before fetch runs.
+	Val V
+
+	// Err is the stored fill error (from [FetchFunc] or [Cache.MaybeSet]),
+	// or nil. A non-nil Err does not make the entry invalid; the error is
+	// treated like any other cached result.
+	Err error
 }
 
-// Event is a cache event.
+// Event is a notification of a cache operation, as delivered to [OnEvent]
+// channels. It extends [Entry] with the operation kind ([Op]).
 type Event[K comparable, V any] struct {
+	// Entry carries the affected (Cache, Key, Val, Err).
 	Entry[K, V]
+
+	// Op identifies the operation that triggered the event: one of
+	// [OpHit], [OpMiss], [OpFill], or [OpEvict].
 	Op Op
 }
 
-// OnEvent is an [Opt] argument to [New] that configures the cache to emit
-// events on the given chan. If ops is empty, all events are emitted; otherwise,
-// only events for the given ops are emitted.
+// OnEvent returns an [Opt] for [New] that configures the cache to emit
+// [Event] values on ch. If ops is empty, events for all four operations
+// ([OpHit], [OpMiss], [OpFill], [OpEvict]) are delivered; otherwise, only
+// events whose [Op] is in ops are delivered. Duplicate ops are coalesced.
 //
-// If arg block is true, the [Cache] function that triggered the event will
-// block on sending to a full ch. If false, the new event is dropped if ch is
-// full.
+// The block parameter controls backpressure behavior when ch is full:
+//   - block=true: the [Cache] operation that produced the event blocks on
+//     the send. Use with an unbuffered (or small-buffered) ch to prevent
+//     the consumer from falling behind the cache.
+//   - block=false: the event is dropped if ch cannot receive immediately.
+//     Use with a buffered ch when event loss under backpressure is
+//     acceptable.
 //
-// You can use an unbuffered channel and block=true to stop the event consumer
-// from falling too far behind the cache state. Alternatively the synchronous
-// [OnHit], [OnMiss], [OnFill], and [OnEvict] callbacks can be used, at cost of
-// increased lock contention and lower throughput.
+// Caveats:
+//   - OnEvent does not forward the triggering ctx on the event; the event
+//     consumer cannot honor cancellation of the producing goroutine.
+//   - With block=true, if the consumer goroutine dies, the triggering
+//     [Cache] method hangs indefinitely.
+//   - The caller owns ch. OnEvent never closes ch.
 //
-// For basic logging, consider [oncecache.Log].
+// Related: for long-running work, OnEvent with a buffered channel is
+// usually better than the synchronous [OnFill]/[OnEvict]/[OnHit]/[OnMiss]
+// callbacks. For basic logging, see [Log].
 func OnEvent[K comparable, V any](ch chan<- Event[K, V], block bool, ops ...Op) Opt {
 	ops = uniq(ops)
 	if len(ops) == 0 {
@@ -45,6 +80,10 @@ func OnEvent[K comparable, V any](ch chan<- Event[K, V], block bool, ops ...Op) 
 	return eventOpt[K, V]{ch: ch, block: block, ops: uniq(ops)}
 }
 
+// eventOpt is the [Opt] returned by [OnEvent]. It carries the destination
+// channel, the set of ops to deliver, and the block/drop mode. Its apply
+// method installs a synthetic callback for each op that packages a
+// callback invocation into an [Event] and sends it (blocking or not).
 type eventOpt[K comparable, V any] struct {
 	ch    chan<- Event[K, V]
 	ops   []Op
@@ -91,8 +130,10 @@ func (o eventOpt[K, V]) apply(c *Cache[K, V]) { //nolint:unused // linter is wro
 	}
 }
 
-// callbackOpt is [Opt] type returned by [OnFill], [OnEvict], [OnHit], and
-// [OnMiss].
+// callbackOpt is the [Opt] type returned by [OnFill], [OnEvict], [OnHit],
+// and [OnMiss]. It carries the registered function and the [Op] it should
+// fire for. The apply method appends fn to the corresponding on* slice on
+// the [Cache] during construction.
 type callbackOpt[K comparable, V any] struct {
 	fn callbackFunc[K, V]
 	op Op
@@ -116,83 +157,113 @@ func (o callbackOpt[K, V]) apply(c *Cache[K, V]) { //nolint:unused // linter is 
 	}
 }
 
-// OnFill returns a callback [Opt] for [New] that is invoked when a cache entry
-// is populated, whether on-demand via [Cache.Get] and [FetchFunc], or
-// externally via [Cache.MaybeSet].
+// OnFill returns an [Opt] for [New] that registers fn as a synchronous
+// callback invoked after a cache entry is populated — either on demand
+// (via [Cache.Get] and [FetchFunc]) or externally (via [Cache.MaybeSet]).
+// fn receives the key, the stored value, and the stored fill error.
 //
-// Note that [OnFill] callbacks are synchronous; the triggering call to
-// [Cache.MaybeSet] or [Cache.Get] blocks until every [OnFill] returns. Consider
-// using [OnEvent] for long-running callbacks.
+// OnFill callbacks run synchronously on the goroutine that triggered the
+// fill: the triggering [Cache.Get] or [Cache.MaybeSet] call blocks until
+// every registered OnFill returns. Prefer [OnEvent] for long-running or
+// blocking work.
 //
-// While [OnFill] can be used for logging, metrics, etc., most common tasks are
-// better accomplished via [OnEvent].
+// Multiple OnFill callbacks may be registered; they fire in registration
+// order. Common uses include metrics emission and propagating entries
+// between composite caches (see the hrsystem example for the latter).
+//
+// ctx is decorated with the source [Cache], retrievable via [FromContext].
 func OnFill[K comparable, V any](fn func(ctx context.Context, key K, val V, err error)) Opt {
 	return callbackOpt[K, V]{op: OpFill, fn: fn}
 }
 
-// OnEvict returns a callback [Opt] for [New] that is invoked when a cache entry
-// is evicted via [Cache.Delete] or [Cache.Clear].
+// OnEvict returns an [Opt] for [New] that registers fn as a synchronous
+// callback invoked after a cache entry is removed via [Cache.Delete] or
+// [Cache.Clear]. fn receives the key and the entry's stored (val, err) at
+// the time of eviction.
 //
-// Note that [OnEvict] callbacks are synchronous; the triggering call to
-// [Cache.Delete] or [Cache.Clear] blocks until every [OnEvict] returns.
-// Consider using [OnEvent] for long-running callbacks.
+// OnEvict callbacks run synchronously on the goroutine that triggered the
+// eviction, while [Cache]'s internal lock is held. They must therefore not
+// call any method on the same cache (that would deadlock). Calls on other
+// caches are fine — this is the foundation of the composite-cache
+// propagation pattern.
+//
+// If the entry is still being filled when [Cache.Delete] or [Cache.Clear]
+// runs, OnEvict is not invoked for that entry; see [Cache.Delete].
 func OnEvict[K comparable, V any](fn func(ctx context.Context, key K, val V, err error)) Opt {
 	return callbackOpt[K, V]{op: OpEvict, fn: fn}
 }
 
-// OnHit returns a callback [Opt] for [New] that is invoked when [Cache.Get]
-// results in a cache hit.
+// OnHit returns an [Opt] for [New] that registers fn as a synchronous
+// callback invoked when [Cache.Get] returns an already-populated entry
+// (a cache hit). fn receives the key and the stored (val, err).
 //
-// Note that [OnHit] callbacks are synchronous; the triggering call to
-// [Cache.Get] blocks until every [OnHit] returns. Consider using the
-// asynchronous [OnEvent] for long-running callbacks.
+// An entry with a non-nil fill error is a valid hit: OnHit is invoked with
+// the stored error, and [OpHit] is emitted.
+//
+// The triggering [Cache.Get] blocks until every OnHit returns. For
+// long-running work, prefer [OnEvent].
 func OnHit[K comparable, V any](fn func(ctx context.Context, key K, val V, err error)) Opt {
 	return callbackOpt[K, V]{op: OpHit, fn: fn}
 }
 
-// OnMiss returns a callback [Opt] for [New] that is invoked when [Cache.Get]
-// results in a cache miss.
+// OnMiss returns an [Opt] for [New] that registers fn as a synchronous
+// callback invoked when [Cache.Get] observes a cache miss, before fetch
+// runs. OnMiss fires only once per entry lifetime; it is always followed
+// by a successful [OpFill] (unless fetch panics, in which case [OpFill]
+// does not fire — see [FetchFunc]).
 //
-// Note that [OnMiss] callbacks are synchronous; the triggering call to
-// [Cache.Get] blocks until every [OnMiss] returns. Consider using the
-// asynchronous [OnEvent] for long-running callbacks.
+// The fn signature intentionally omits val and err because neither is
+// defined yet at miss time. OnMiss callbacks run synchronously; the
+// triggering [Cache.Get] blocks until they return. Prefer [OnEvent] for
+// long-running work.
 //
-// FIXME: Starting to think OnMiss should just use the standard callback signature.
+// OnMiss is not emitted by [Cache.MaybeSet], since MaybeSet is not a
+// [Cache.Get] miss path.
 func OnMiss[K comparable, V any](fn func(ctx context.Context, key K)) Opt {
 	return callbackOpt[K, V]{op: OpMiss, fn: func(ctx context.Context, key K, _ V, _ error) {
 		fn(ctx, key)
 	}}
 }
 
-// Op is an enumeration of cache operations, as see in [Event.Op].
+// Op is an enumeration of cache operations. It is the kind field of [Event]
+// and the selector used by [OnEvent] and [Log] to filter which operations
+// trigger delivery. The zero value is invalid; use [Op.IsZero] to detect it.
 type Op uint8
 
 const (
-	// OpHit indicates a cache hit: a cache entry already exists for the key. Note
-	// that the cache entry may contain a non-nil error, and the entry value may
-	// be the zero value. An errorful cache entry is a valid hit.
+	// OpHit indicates a cache hit: [Cache.Get] found an already-populated
+	// entry for the key. A hit may carry a non-nil [Entry.Err] (an entry
+	// whose fill returned an error is still a valid, cacheable result).
 	OpHit Op = 1
 
-	// OpMiss indicates a cache miss. It is always immediately followed by an
-	// [OpFill].
+	// OpMiss indicates a cache miss: [Cache.Get] found no entry for the
+	// key and is about to invoke [FetchFunc]. OpMiss fires once per entry
+	// lifetime and is (in the normal case) immediately followed by
+	// [OpFill]. If [FetchFunc] panics, OpFill will not fire; see
+	// [FetchFunc].
 	OpMiss Op = 2
 
-	// OpFill indicates that a cache entry has been populated. Typically it is
-	// immediately preceded by [OpMiss], but will occur standalone when
-	// [Cache.Set] is invoked. Note that if the entry fill results in an error,
-	// the entry is still considered valid, and [OpFill] is still emitted.
+	// OpFill indicates that a cache entry has been populated. It is
+	// preceded by [OpMiss] when the fill was driven by [Cache.Get], or
+	// emitted standalone when the fill was driven by [Cache.MaybeSet]. An
+	// entry filled with a non-nil error still emits OpFill; the error is
+	// cached like any other result.
 	OpFill Op = 3
 
-	// OpEvict indicates a cache entry has been removed.
+	// OpEvict indicates a cache entry has been removed via [Cache.Delete]
+	// or [Cache.Clear]. An in-flight fill (one whose [FetchFunc] has not
+	// yet completed) does not emit OpEvict when it is removed: see
+	// [Cache.Delete].
 	OpEvict Op = 4
 )
 
-// IsZero returns true if the action is the zero value, which is an invalid Op.
+// IsZero reports whether o is the zero value (the invalid [Op]).
 func (o Op) IsZero() bool {
 	return o == 0
 }
 
-// String returns the op name.
+// String returns the op name: "hit", "miss", "fill", or "evict". For any
+// other value (including the zero [Op]) it returns "unknown".
 func (o Op) String() string {
 	switch o {
 	case OpFill:

--- a/event.go
+++ b/event.go
@@ -38,10 +38,18 @@ type Entry[K comparable, V any] struct {
 }
 
 // Event is a notification of a cache operation, as delivered to [OnEvent]
-// channels. It extends [Entry] with the operation kind ([Op]).
+// channels. It extends [Entry] with the operation kind ([Op]) and the
+// triggering context.
 type Event[K comparable, V any] struct {
 	// Entry carries the affected (Cache, Key, Val, Err).
 	Entry[K, V]
+
+	// Ctx is the context of the [Cache] operation that produced the
+	// event, decorated with the source [Cache] (retrievable via
+	// [FromContext]). Consumers may use Ctx for trace propagation or to
+	// observe cancellation of the producing goroutine. Always non-nil
+	// for events produced by this package.
+	Ctx context.Context
 
 	// Op identifies the operation that triggered the event: one of
 	// [OpHit], [OpMiss], [OpFill], or [OpEvict].
@@ -56,34 +64,34 @@ type Event[K comparable, V any] struct {
 // The block parameter controls backpressure behavior when ch is full:
 //   - block=true: the [Cache] operation that produced the event blocks on
 //     the send. Use with an unbuffered (or small-buffered) ch to prevent
-//     the consumer from falling behind the cache.
+//     the consumer from falling behind the cache. The send aborts if the
+//     triggering ctx is cancelled, dropping the event.
 //   - block=false: the event is dropped if ch cannot receive immediately.
 //     Use with a buffered ch when event loss under backpressure is
 //     acceptable.
 //
-// Caveats:
-//   - OnEvent does not forward the triggering ctx on the event; the event
-//     consumer cannot honor cancellation of the producing goroutine.
-//   - With block=true, if the consumer goroutine dies, the triggering
-//     [Cache] method hangs indefinitely.
-//   - The caller owns ch. OnEvent never closes ch.
+// Each delivered [Event] carries the triggering context as [Event.Ctx],
+// so consumers can extract the source [Cache] via [FromContext], honor
+// cancellation, or propagate trace state.
 //
-// Related: for long-running work, OnEvent with a buffered channel is
-// usually better than the synchronous [OnFill]/[OnEvict]/[OnHit]/[OnMiss]
-// callbacks. For basic logging, see [Log].
+// The caller owns ch. OnEvent never closes ch.
+//
+// For long-running work, OnEvent with a buffered channel is usually better
+// than the synchronous [OnFill]/[OnEvict]/[OnHit]/[OnMiss] callbacks. For
+// basic logging, see [Log].
 func OnEvent[K comparable, V any](ch chan<- Event[K, V], block bool, ops ...Op) Opt {
 	ops = uniq(ops)
 	if len(ops) == 0 {
-		ops = []Op{OpFill, OpEvict, OpHit, OpMiss}
+		ops = []Op{OpHit, OpMiss, OpFill, OpEvict}
 	}
-
-	return eventOpt[K, V]{ch: ch, block: block, ops: uniq(ops)}
+	return eventOpt[K, V]{ch: ch, block: block, ops: ops}
 }
 
 // eventOpt is the [Opt] returned by [OnEvent]. It carries the destination
 // channel, the set of ops to deliver, and the block/drop mode. Its apply
 // method installs a synthetic callback for each op that packages a
-// callback invocation into an [Event] and sends it (blocking or not).
+// callback invocation into an [Event] and sends it (blocking, with ctx
+// cancellation, or non-blocking with drop).
 type eventOpt[K comparable, V any] struct {
 	ch    chan<- Event[K, V]
 	ops   []Op
@@ -94,20 +102,24 @@ func (o eventOpt[K, V]) optioner() {}
 
 func (o eventOpt[K, V]) apply(c *Cache[K, V]) { //nolint:unused // linter is wrong, method is invoked.
 	for _, op := range o.ops {
-		op := op
-		fn := func(_ context.Context, key K, val V, err error) {
+		fn := func(ctx context.Context, key K, val V, err error) {
 			event := Event[K, V]{
 				Op:    op,
+				Ctx:   ctx,
 				Entry: Entry[K, V]{Cache: c, Key: key, Val: val, Err: err},
 			}
 
 			if o.block {
-				// Blocking.
-				o.ch <- event
+				// Blocking, with ctx cancellation so a dead consumer
+				// doesn't hang the producer indefinitely.
+				select {
+				case o.ch <- event:
+				case <-ctx.Done():
+				}
 				return
 			}
 
-			// Non-blocking.
+			// Non-blocking: drop on full.
 			select {
 			case o.ch <- event:
 			default:
@@ -124,8 +136,7 @@ func (o eventOpt[K, V]) apply(c *Cache[K, V]) { //nolint:unused // linter is wro
 		case OpMiss:
 			c.onMiss = append(c.onMiss, fn)
 		default:
-			// Shouldn't happen.
-			panic(fmt.Sprintf("unknown action: %v: %s", op, op))
+			panic(fmt.Sprintf("unknown op: %v: %s", op, op))
 		}
 	}
 }
@@ -208,21 +219,22 @@ func OnHit[K comparable, V any](fn func(ctx context.Context, key K, val V, err e
 
 // OnMiss returns an [Opt] for [New] that registers fn as a synchronous
 // callback invoked when [Cache.Get] observes a cache miss, before fetch
-// runs. OnMiss fires only once per entry lifetime; it is always followed
-// by a successful [OpFill] (unless fetch panics, in which case [OpFill]
-// does not fire — see [FetchFunc]).
+// runs. OnMiss fires only once per entry lifetime; it is followed by an
+// [OpFill] (with either the fetch result or a panic-wrapped error — see
+// [FetchFunc]).
 //
-// The fn signature intentionally omits val and err because neither is
-// defined yet at miss time. OnMiss callbacks run synchronously; the
-// triggering [Cache.Get] blocks until they return. Prefer [OnEvent] for
-// long-running work.
+// The val and err arguments to fn are always the zero values, since the
+// entry has not yet been populated at miss time; they exist solely so that
+// OnMiss shares the standard callback signature with [OnFill], [OnHit],
+// and [OnEvict] (and so the V type parameter is inferable from fn).
+//
+// OnMiss callbacks run synchronously; the triggering [Cache.Get] blocks
+// until they return. Prefer [OnEvent] for long-running work.
 //
 // OnMiss is not emitted by [Cache.MaybeSet], since MaybeSet is not a
 // [Cache.Get] miss path.
-func OnMiss[K comparable, V any](fn func(ctx context.Context, key K)) Opt {
-	return callbackOpt[K, V]{op: OpMiss, fn: func(ctx context.Context, key K, _ V, _ error) {
-		fn(ctx, key)
-	}}
+func OnMiss[K comparable, V any](fn func(ctx context.Context, key K, val V, err error)) Opt {
+	return callbackOpt[K, V]{op: OpMiss, fn: fn}
 }
 
 // Op is an enumeration of cache operations. It is the kind field of [Event]

--- a/event.go
+++ b/event.go
@@ -193,10 +193,9 @@ func OnFill[K comparable, V any](fn func(ctx context.Context, key K, val V, err 
 // the time of eviction.
 //
 // OnEvict callbacks run synchronously on the goroutine that triggered the
-// eviction, while [Cache]'s internal lock is held. They must therefore not
-// call any method on the same cache (that would deadlock). Calls on other
-// caches are fine — this is the foundation of the composite-cache
-// propagation pattern.
+// eviction, after [Cache]'s internal lock has been released. fn may
+// therefore safely call methods on the same cache (or on other caches —
+// this is the foundation of the composite-cache propagation pattern).
 //
 // If the entry is still being filled when [Cache.Delete] or [Cache.Clear]
 // runs, OnEvict is not invoked for that entry; see [Cache.Delete].
@@ -250,8 +249,9 @@ const (
 
 	// OpMiss indicates a cache miss: [Cache.Get] found no entry for the
 	// key and is about to invoke [FetchFunc]. OpMiss fires once per entry
-	// lifetime and is (in the normal case) immediately followed by
-	// [OpFill]. If [FetchFunc] panics, OpFill will not fire; see
+	// lifetime and is immediately followed by [OpFill] — including when
+	// [FetchFunc] panics, in which case the panic is recovered into an
+	// error wrapping [ErrPanic] and OpFill carries that error. See
 	// [FetchFunc].
 	OpMiss Op = 2
 

--- a/examples/hrsystem/cache.go
+++ b/examples/hrsystem/cache.go
@@ -72,7 +72,7 @@ func (c *HRCache) GetDepartment(ctx context.Context, deptName string) (*Departme
 	if err == nil {
 		c.log.Info("GetDepartment", "dept", dept)
 	} else {
-		c.log.Error("GetDepartment", "dept", dept.Name, "error", err.Error())
+		c.log.Error("GetDepartment", "dept", deptName, "error", err)
 	}
 
 	return dept, err

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,10 @@
 module github.com/neilotoole/oncecache
 
-go 1.21
+go 1.22
 
 require (
 	github.com/neilotoole/slogt v1.1.0
 	github.com/stretchr/testify v1.9.0
-	golang.org/x/exp v0.0.0-20240222234643-814bf88cf225
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-golang.org/x/exp v0.0.0-20240222234643-814bf88cf225 h1:LfspQV/FYTatPTr/3HzIcmiUFH7PGP+OQ6mgDYo3yuQ=
-golang.org/x/exp v0.0.0-20240222234643-814bf88cf225/go.mod h1:CxmFvTBINI24O/j8iY7H1xHzx2i4OsyguNBmN/uPtqc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/log.go
+++ b/log.go
@@ -134,40 +134,42 @@ func (o *logOpt[K, V]) apply(c *Cache[K, V]) {
 	}
 }
 
-func (o *logOpt[K, V]) logEvent(ev Event[K, V]) {
-	o.log.LogAttrs(context.Background(), o.lvl.Level(), LogConfig.Msg, slog.Any(LogConfig.AttrEvent, ev))
+// logEvent emits a slog record for ev under ctx. The forwarded ctx
+// preserves trace/span attribution from the triggering Cache call.
+func (o *logOpt[K, V]) logEvent(ctx context.Context, ev Event[K, V]) {
+	o.log.LogAttrs(ctx, o.lvl.Level(), LogConfig.Msg, slog.Any(LogConfig.AttrEvent, ev))
 }
 
 func (o *logOpt[K, V]) logHit(ctx context.Context, key K, val V, err error) {
-	ev := Event[K, V]{
+	o.logEvent(ctx, Event[K, V]{
 		Op:    OpHit,
+		Ctx:   ctx,
 		Entry: Entry[K, V]{Cache: FromContext[K, V](ctx), Key: key, Val: val, Err: err},
-	}
-	o.logEvent(ev)
+	})
 }
 
 func (o *logOpt[K, V]) logMiss(ctx context.Context, key K, val V, err error) {
-	ev := Event[K, V]{
+	o.logEvent(ctx, Event[K, V]{
 		Op:    OpMiss,
+		Ctx:   ctx,
 		Entry: Entry[K, V]{Cache: FromContext[K, V](ctx), Key: key, Val: val, Err: err},
-	}
-	o.logEvent(ev)
+	})
 }
 
 func (o *logOpt[K, V]) logFill(ctx context.Context, key K, val V, err error) {
-	ev := Event[K, V]{
+	o.logEvent(ctx, Event[K, V]{
 		Op:    OpFill,
+		Ctx:   ctx,
 		Entry: Entry[K, V]{Cache: FromContext[K, V](ctx), Key: key, Val: val, Err: err},
-	}
-	o.logEvent(ev)
+	})
 }
 
 func (o *logOpt[K, V]) logEvict(ctx context.Context, key K, val V, err error) {
-	ev := Event[K, V]{
+	o.logEvent(ctx, Event[K, V]{
 		Op:    OpEvict,
+		Ctx:   ctx,
 		Entry: Entry[K, V]{Cache: FromContext[K, V](ctx), Key: key, Val: val, Err: err},
-	}
-	o.logEvent(ev)
+	})
 }
 
 // LogValue implements [slog.LogValuer] for [Event]. The emitted group
@@ -177,7 +179,7 @@ func (o *logOpt[K, V]) logEvict(ctx context.Context, key K, val V, err error) {
 // from [LogConfig].
 func (e Event[K, V]) LogValue() slog.Value {
 	attrs := make([]slog.Attr, 3, 5)
-	attrs[0] = slog.String(LogConfig.AttrCache, e.Cache.name)
+	attrs[0] = slog.String(LogConfig.AttrCache, e.Cache.Name())
 	attrs[1] = slog.String(LogConfig.AttrOp, e.Op.String())
 	attrs[2] = slog.Any(LogConfig.AttrKey, e.Key)
 
@@ -199,7 +201,7 @@ func (e Event[K, V]) LogValue() slog.Value {
 // may not be printable; for structured output, use [Event.LogValue].
 func (e Event[K, V]) String() string {
 	var sb strings.Builder
-	sb.WriteString(e.Cache.name)
+	sb.WriteString(e.Cache.Name())
 	sb.WriteRune('.')
 	sb.WriteString(e.Op.String())
 	sb.WriteRune('[')
@@ -219,7 +221,7 @@ func (e Event[K, V]) String() string {
 // be printable; for structured output, use [Entry.LogValue].
 func (e Entry[K, V]) String() string {
 	sb := strings.Builder{}
-	sb.WriteString(e.Cache.name)
+	sb.WriteString(e.Cache.Name())
 	sb.WriteRune('[')
 	sb.WriteString(fmt.Sprintf("%v", e.Key))
 	sb.WriteRune(']')
@@ -240,7 +242,7 @@ func (e Entry[K, V]) String() string {
 // payload. Attribute names come from [LogConfig].
 func (e Entry[K, V]) LogValue() slog.Value {
 	attrs := make([]slog.Attr, 2, 4)
-	attrs[0] = slog.String(LogConfig.AttrCache, e.Cache.name)
+	attrs[0] = slog.String(LogConfig.AttrCache, e.Cache.Name())
 	attrs[1] = slog.Any(LogConfig.AttrKey, e.Key)
 
 	if e.isValLogged() {

--- a/log.go
+++ b/log.go
@@ -7,8 +7,22 @@ import (
 	"strings"
 )
 
-// LogConfig is used by [oncecache.Log] to configure log output.
-// See also: [oncecache.Event.LogValue], [oncecache.Entry.LogValue].
+// LogConfig holds process-wide defaults for how [Log] formats slog output
+// and how [Event.LogValue] / [Entry.LogValue] name their attributes. Mutate
+// this package-level variable at program startup to customize log output;
+// the values are read on each log call.
+//
+// Fields:
+//   - Msg:       the slog message text used by [Log] (default: "Cache event").
+//   - AttrEvent: the top-level group key under which event attrs are nested
+//     when a whole [Event] is logged (default: "ev").
+//   - AttrCache: attribute name for the cache name (default: "cache").
+//   - AttrOp:    attribute name for the [Op] (default: "op").
+//   - AttrKey:   attribute name for the entry key (default: "k").
+//   - AttrVal:   attribute name for the entry value (default: "v"; only
+//     emitted for primitive V types and [slog.LogValuer] — see
+//     [Entry.LogValue]).
+//   - AttrErr:   attribute name for the entry error (default: "err").
 var LogConfig = struct {
 	Msg       string
 	AttrEvent string
@@ -27,9 +41,19 @@ var LogConfig = struct {
 	AttrErr:   "err",
 }
 
-// Log is an [Opt] for [oncecache.New] that logs each [Event] to log, where
-// [Event.Op] is in ops. If ops is empty, all events are logged. If log is nil,
-// Log is a no-op. If lvl is nil, [slog.LevelInfo] is used. Example usage:
+// Log returns an [Opt] for [New] that emits an [slog] record for each
+// matching [Event]. It is the simplest way to wire cache activity into
+// structured logging.
+//
+// Parameters:
+//   - log: destination logger. If nil, Log returns nil and registers
+//     nothing (treated as a no-op Opt).
+//   - lvl: the level at which to log. Nil is treated as [slog.LevelInfo].
+//   - ops: which operations to log. If empty, all four ops are logged.
+//     Duplicates are coalesced.
+//
+// Multiple Log opts can be combined to log different ops at different
+// levels — for example, Fill/Evict at Info and Hit/Miss at Debug:
 //
 //	c := oncecache.New[int, int](
 //		calcFibonacci,
@@ -38,10 +62,14 @@ var LogConfig = struct {
 //		oncecache.Log(log, slog.LevelDebug, oncecache.OpHit, oncecache.OpMiss),
 //	)
 //
-// Log is intended to handle basic logging needs. Some configuration is possible
-// via [oncecache.LogConfig]. If you require more control, you can roll your own
-// logging mechanism using an [OnEvent] channel or the On* callbacks. If doing
-// so, note that [Event], [Entry] and [Cache] each implement [slog.LogValuer].
+// Output format: each record has the message [LogConfig].Msg and a single
+// attribute group (default key "ev") whose contents are determined by
+// [Event.LogValue]. Customize attribute names via [LogConfig].
+//
+// For more control than Log provides, use an [OnEvent] channel or the
+// synchronous On* callbacks directly; note that [Event], [Entry], and
+// [Cache] all implement [slog.LogValuer], so they format cleanly in any
+// slog output.
 func Log(log *slog.Logger, lvl slog.Leveler, ops ...Op) Opt {
 	if log == nil {
 		return nil
@@ -66,6 +94,11 @@ func Log(log *slog.Logger, lvl slog.Leveler, ops ...Op) Opt {
 
 var _ Opt = logOptConfig{}
 
+// logOptConfig is the non-parameterized payload returned by [Log]. It is
+// non-generic so that callers can write `oncecache.Log(...)` without
+// spelling out the [Cache]'s K and V type parameters. The parameterized
+// twin [logOpt] is structurally identical and is produced by
+// (*Cache).applyOpts via a pointer cast at apply time.
 type logOptConfig struct {
 	log *slog.Logger
 	lvl slog.Leveler
@@ -76,6 +109,9 @@ func (o logOptConfig) optioner() {}
 
 var _ Opt = &logOpt[any, any]{}
 
+// logOpt is the parameterized twin of [logOptConfig]; see its doc for the
+// rationale. logOpt exists so its methods can touch the parameterized
+// [Cache] fields (the on* callback slices).
 type logOpt[K comparable, V any] logOptConfig
 
 func (o *logOpt[K, V]) optioner() {}
@@ -134,8 +170,11 @@ func (o *logOpt[K, V]) logEvict(ctx context.Context, key K, val V, err error) {
 	o.logEvent(ev)
 }
 
-// LogValue implements [slog.LogValuer], logging according to [Entry.LogValue],
-// but also logging [Event.Op].
+// LogValue implements [slog.LogValuer] for [Event]. The emitted group
+// contains (at minimum) the cache name, op, and key. For non-[OpMiss]
+// events it also includes the stored value (when loggable — see
+// [Entry.LogValue]) and error (when non-nil). Attribute names are taken
+// from [LogConfig].
 func (e Event[K, V]) LogValue() slog.Value {
 	attrs := make([]slog.Attr, 3, 5)
 	attrs[0] = slog.String(LogConfig.AttrCache, e.Cache.name)
@@ -154,8 +193,10 @@ func (e Event[K, V]) LogValue() slog.Value {
 	return slog.GroupValue(attrs...)
 }
 
-// String returns a string representation of the event. The event's Val field
-// is not incorporated. For logging, note [Event.LogValue].
+// String returns a compact debug representation of the event in the form
+// "<cacheName>.<op>[<key>]" with an optional "[! <err>]" suffix when the
+// entry has a non-nil error. The value is deliberately omitted because V
+// may not be printable; for structured output, use [Event.LogValue].
 func (e Event[K, V]) String() string {
 	var sb strings.Builder
 	sb.WriteString(e.Cache.name)
@@ -172,8 +213,10 @@ func (e Event[K, V]) String() string {
 	return sb.String()
 }
 
-// String returns a string representation of the entry. The entry's Val field
-// is not incorporated. For logging, note [Entry.LogValue].
+// String returns a compact debug representation of the entry in the form
+// "<cacheName>[<key>]" with an optional "[! <err>]" suffix when the entry
+// has a non-nil error. The value is deliberately omitted because V may not
+// be printable; for structured output, use [Entry.LogValue].
 func (e Entry[K, V]) String() string {
 	sb := strings.Builder{}
 	sb.WriteString(e.Cache.name)
@@ -188,9 +231,13 @@ func (e Entry[K, V]) String() string {
 	return sb.String()
 }
 
-// LogValue implements [slog.LogValuer], logging Val if it implements
-// [slog.LogValuer] or is a primitive type such as int or bool (but not string),
-// logging Err if non-nil, and always logging Key and [Cache.Name].
+// LogValue implements [slog.LogValuer] for [Entry]. The emitted group
+// always contains the cache name and the key; it includes the stored
+// value only when V is a type safe to log via slog (primitive numeric
+// types, bool, or any [slog.LogValuer]); and includes the error only
+// when non-nil. In particular, string values are NOT logged, to avoid
+// unbounded-length log lines for caches whose V is a large string
+// payload. Attribute names come from [LogConfig].
 func (e Entry[K, V]) LogValue() slog.Value {
 	attrs := make([]slog.Attr, 2, 4)
 	attrs[0] = slog.String(LogConfig.AttrCache, e.Cache.name)
@@ -206,9 +253,13 @@ func (e Entry[K, V]) LogValue() slog.Value {
 	return slog.GroupValue(attrs...)
 }
 
-// isValLogged returns true if the Entry's Val field should be logged. Only
-// primitive types and [slog.LogValuer] are logged. In particular, note that
-// string is not logged.
+// isValLogged reports whether the entry's Val field is safe to emit as a
+// slog attribute. The rule is deliberately conservative: only fixed-size
+// primitive types (numeric kinds, bool) and types that implement
+// [slog.LogValuer] (and can thus control their own log representation)
+// are included. String is excluded because cache values are often large
+// payloads; callers who want string values in logs should wrap their V
+// in a type that implements [slog.LogValuer].
 func (e Entry[K, V]) isValLogged() bool {
 	switch any(e.Val).(type) {
 	case slog.LogValuer, bool, nil, int, int8, int16, int32, int64,

--- a/log.go
+++ b/log.go
@@ -205,7 +205,7 @@ func (e Event[K, V]) String() string {
 	sb.WriteRune('.')
 	sb.WriteString(e.Op.String())
 	sb.WriteRune('[')
-	sb.WriteString(fmt.Sprintf("%v", e.Key))
+	fmt.Fprintf(&sb, "%v", e.Key)
 	sb.WriteRune(']')
 	if e.Err != nil {
 		sb.WriteString("[! ")
@@ -223,7 +223,7 @@ func (e Entry[K, V]) String() string {
 	sb := strings.Builder{}
 	sb.WriteString(e.Cache.Name())
 	sb.WriteRune('[')
-	sb.WriteString(fmt.Sprintf("%v", e.Key))
+	fmt.Fprintf(&sb, "%v", e.Key)
 	sb.WriteRune(']')
 	if e.Err != nil {
 		sb.WriteString("[! ")

--- a/oncecache.go
+++ b/oncecache.go
@@ -221,10 +221,10 @@ type Cache[K comparable, V any] struct {
 	// maybeSetValueFn and getValueFn are selected at construction time
 	// based on which callbacks are registered. The "fast" variants skip
 	// callback-iteration overhead when no relevant callbacks exist. The
-	// cache is passed as the first argument rather than stored on each
-	// entry, saving one pointer per entry.
-	maybeSetValueFn func(c *Cache[K, V], ctx context.Context, e *entry[K, V], key K, val V, err error) bool
-	getValueFn      func(c *Cache[K, V], ctx context.Context, e *entry[K, V], key K) (V, error)
+	// cache is passed as an argument rather than stored on each entry,
+	// saving one pointer per entry.
+	maybeSetValueFn func(ctx context.Context, c *Cache[K, V], e *entry[K, V], key K, val V, err error) bool
+	getValueFn      func(ctx context.Context, c *Cache[K, V], e *entry[K, V], key K) (V, error)
 
 	// name is set via the Name opt, or a random value if not specified.
 	// Stored as atomic.Pointer[string] so [Cache.Name] / [Cache.String] /
@@ -397,7 +397,7 @@ func (c *Cache[K, V]) Delete(ctx context.Context, key K) {
 // [OnMiss] is not emitted, since MaybeSet is not a [Cache.Get] miss.
 func (c *Cache[K, V]) MaybeSet(ctx context.Context, key K, val V, err error) (ok bool) {
 	e := c.getEntry(key)
-	return c.maybeSetValueFn(c, ctx, e, key, val, err)
+	return c.maybeSetValueFn(ctx, c, e, key, val, err)
 }
 
 // Get returns the cached value (and fill error) for key. On a cache miss,
@@ -414,11 +414,13 @@ func (c *Cache[K, V]) MaybeSet(ctx context.Context, key K, val V, err error) (ok
 // Concurrent Get calls for the same unfilled key block until the in-flight
 // fetch completes and then all receive the same (val, err).
 //
-// If fetch panics, the panic propagates to this Get caller; see [FetchFunc]
-// for the post-panic entry state.
+// If fetch panics, the panic is recovered and converted into a fill error
+// wrapping [ErrPanic]; Get returns (zero, that wrapped error) instead of
+// propagating the panic. [OpFill] still fires with the wrapped error. See
+// [FetchFunc] for details.
 func (c *Cache[K, V]) Get(ctx context.Context, key K) (V, error) {
 	e := c.getEntry(key)
-	return c.getValueFn(c, ctx, e, key)
+	return c.getValueFn(ctx, c, e, key)
 }
 
 // getEntry returns the entry for key, creating (but not yet populating) one
@@ -515,6 +517,12 @@ func (c *Cache[K, V]) GobEncode() ([]byte, error) {
 // are marked as filled, so subsequent [Cache.Get] calls return them directly
 // without invoking fetch.
 //
+// Unlike other methods, GobDecode is safe to call on a zero-value [Cache]
+// (as gob-provided decoding into `var c Cache[K, V]` will do): it
+// initializes the internal map on demand. The decoded cache will have no
+// fetch func and no callbacks; set those via [New] if needed before
+// further use.
+//
 // The error type(s) used in entries with non-nil fill errors must be
 // registered with [gob.Register] before encoding/decoding.
 //
@@ -531,7 +539,11 @@ func (c *Cache[K, V]) GobDecode(p []byte) error {
 
 	name := gbd.Name
 	c.name.Store(&name)
-	clear(c.entries)
+	if c.entries == nil {
+		c.entries = make(map[K]*entry[K, V], len(gbd.Entries))
+	} else {
+		clear(c.entries)
+	}
 	for k, e := range gbd.Entries {
 		ent := &entry[K, V]{val: e.Val, err: e.Err}
 		ent.once.Do(func() {}) // Consume the sync.Once
@@ -560,15 +572,17 @@ type entry[K comparable, V any] struct {
 	filled atomic.Bool
 }
 
-// fillPanic wraps a recovered panic value into an error that can be stored
-// in a cache entry. It unwraps to [ErrPanic] so callers can test via
-// [errors.Is].
-type fillPanic struct {
-	recovered any
+// fillPanicError wraps a recovered panic value into an error that can be
+// stored in a cache entry. It unwraps to [ErrPanic] so callers can test
+// via [errors.Is]. The recovered panic value is stored as its formatted
+// string representation (not as any) so that errorful entries remain
+// gob-encodable — see [Cache.GobEncode].
+type fillPanicError struct {
+	recovered string
 }
 
-func (p *fillPanic) Error() string { return fmt.Sprintf("%s: %v", ErrPanic, p.recovered) }
-func (p *fillPanic) Unwrap() error { return ErrPanic }
+func (p *fillPanicError) Error() string { return fmt.Sprintf("%s: %s", ErrPanic, p.recovered) }
+func (p *fillPanicError) Unwrap() error { return ErrPanic }
 
 // callFetch invokes c.fetch, recovering any panic and converting it into
 // an error wrapping [ErrPanic]. The recovered panic is NOT re-thrown:
@@ -577,12 +591,12 @@ func (p *fillPanic) Unwrap() error { return ErrPanic }
 //
 // Callback panics (OnMiss, OnFill, OnHit, OnEvict) are deliberately not
 // recovered here; they propagate to the triggering caller.
-func callFetch[K comparable, V any](c *Cache[K, V], ctx context.Context, key K) (val V, err error) {
+func callFetch[K comparable, V any](ctx context.Context, c *Cache[K, V], key K) (val V, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			var zero V
 			val = zero
-			err = &fillPanic{recovered: r}
+			err = &fillPanicError{recovered: fmt.Sprintf("%v", r)}
 		}
 	}()
 	return c.fetch(ctx, key)
@@ -590,7 +604,9 @@ func callFetch[K comparable, V any](c *Cache[K, V], ctx context.Context, key K) 
 
 // maybeSetValueSlow is the MaybeSet core used when OnFill callbacks are
 // registered. See maybeSetValueFast for the no-callback path.
-func maybeSetValueSlow[K comparable, V any](c *Cache[K, V], ctx context.Context, e *entry[K, V], key K, val V, err error) bool {
+func maybeSetValueSlow[K comparable, V any](
+	ctx context.Context, c *Cache[K, V], e *entry[K, V], key K, val V, err error,
+) bool {
 	var ok bool
 	e.once.Do(func() {
 		ok = true
@@ -607,7 +623,9 @@ func maybeSetValueSlow[K comparable, V any](c *Cache[K, V], ctx context.Context,
 
 // maybeSetValueFast is the MaybeSet core used when no OnFill callbacks are
 // registered. It skips callback iteration and the NewContext decoration.
-func maybeSetValueFast[K comparable, V any](_ *Cache[K, V], _ context.Context, e *entry[K, V], _ K, val V, err error) bool {
+func maybeSetValueFast[K comparable, V any](
+	_ context.Context, _ *Cache[K, V], e *entry[K, V], _ K, val V, err error,
+) bool {
 	var ok bool
 	e.once.Do(func() {
 		e.val = val
@@ -624,7 +642,7 @@ func maybeSetValueFast[K comparable, V any](_ *Cache[K, V], _ context.Context, e
 // all inside the entry's sync.Once. On hit it fires OnHit outside the Once
 // (safe: the Once's completion synchronizes the val/err writes for later
 // readers).
-func getValueSlow[K comparable, V any](c *Cache[K, V], ctx context.Context, e *entry[K, V], key K) (V, error) {
+func getValueSlow[K comparable, V any](ctx context.Context, c *Cache[K, V], e *entry[K, V], key K) (V, error) {
 	var miss bool
 	e.once.Do(func() {
 		miss = true
@@ -633,7 +651,7 @@ func getValueSlow[K comparable, V any](c *Cache[K, V], ctx context.Context, e *e
 			fn(cbCtx, key, e.val, e.err)
 		}
 
-		e.val, e.err = callFetch(c, cbCtx, key)
+		e.val, e.err = callFetch(cbCtx, c, key)
 		e.filled.Store(true)
 
 		for _, fn := range c.onFill {
@@ -654,10 +672,10 @@ func getValueSlow[K comparable, V any](c *Cache[K, V], ctx context.Context, e *e
 // getValueFast is the Get core used when no Get-triggered callbacks are
 // registered, which is the common case. It skips the OnMiss/OnFill/OnHit
 // iteration entirely.
-func getValueFast[K comparable, V any](c *Cache[K, V], ctx context.Context, e *entry[K, V], key K) (V, error) {
+func getValueFast[K comparable, V any](ctx context.Context, c *Cache[K, V], e *entry[K, V], key K) (V, error) {
 	e.once.Do(func() {
 		cbCtx := NewContext(ctx, c)
-		e.val, e.err = callFetch(c, cbCtx, key)
+		e.val, e.err = callFetch(cbCtx, c, key)
 		e.filled.Store(true)
 	})
 
@@ -724,8 +742,8 @@ func isNil(x any) bool {
 	if x == nil {
 		return true
 	}
-	v := reflect.ValueOf(x)
-	switch v.Kind() {
+	//nolint:exhaustive // only nilable kinds are listed; all others fall through to false.
+	switch v := reflect.ValueOf(x); v.Kind() {
 	case reflect.Pointer, reflect.Chan, reflect.Func,
 		reflect.Interface, reflect.Map, reflect.Slice:
 		return v.IsNil()

--- a/oncecache.go
+++ b/oncecache.go
@@ -2,8 +2,48 @@
 // dependency-free, in-memory, on-demand object [Cache], focused on write-once,
 // read-often ergonomics.
 //
-// The package also provides an event mechanism useful for logging, metrics, or
-// propagating cache entries between overlapping composite caches.
+// # Model
+//
+// Construct a [Cache] via [New] with a [FetchFunc]. The first [Cache.Get] for
+// a given key runs the fetch func and stores the result; subsequent [Cache.Get]
+// calls return that stored result without reinvoking fetch. Entries may also
+// be populated externally via [Cache.MaybeSet], and removed via [Cache.Delete]
+// or [Cache.Clear], after which they may be populated afresh.
+//
+// A cache entry is a (key, value, error) triple. An entry with a non-nil error
+// is still a valid, fully-populated entry; subsequent [Cache.Get] calls return
+// the stored error without reinvoking fetch. The "once" in oncecache refers to
+// this once-per-entry-lifetime population guarantee.
+//
+// # Scope
+//
+// oncecache is targeted at write-once, read-often situations — where the
+// value for a key is expensive to compute or fetch, is likely to be read many
+// times, and is not expected to change. It is not a general-purpose cache:
+// there is no TTL, no size bound, no background reaper, and no LRU eviction.
+// Callers manage entry lifetime explicitly via [Cache.Delete] and
+// [Cache.Clear].
+//
+// # Events and callbacks
+//
+// The package provides an event/callback mechanism useful for logging,
+// metrics, and cache propagation across composite caches. Synchronous
+// callbacks are registered with [OnFill], [OnEvict], [OnHit], and [OnMiss];
+// channel-based async delivery is available via [OnEvent]; and [Log]
+// configures basic [slog.Logger] integration.
+//
+// # Concurrency
+//
+// [Cache] is safe for concurrent use by multiple goroutines. For any given
+// key, [FetchFunc] is invoked at most once per entry lifetime: if multiple
+// goroutines call [Cache.Get] for the same unfilled key, the first caller
+// runs fetch and subsequent callers block until the fetch completes, then all
+// receive the same result.
+//
+// Synchronous callbacks run on the goroutine that triggered the event. They
+// must not touch the same cache for the same key (that re-enters the entry's
+// [sync.Once] and deadlocks). For long-running callbacks, prefer [OnEvent]
+// with a buffered channel.
 package oncecache
 
 import (
@@ -16,23 +56,58 @@ import (
 	"log/slog"
 	"reflect"
 	"sync"
+	"sync/atomic"
 
 	"golang.org/x/exp/maps"
 )
 
-// FetchFunc is called by [Cache.Get] to fill an unpopulated cache entry. If
-// needed, the source [Cache] can be retrieved from ctx via [FromContext].
+// FetchFunc is called by [Cache.Get] to fill an unpopulated cache entry. It
+// returns the value for key, or an error if the fetch failed.
+//
+// Errors are cached just like successful values: a subsequent [Cache.Get] for
+// the same key returns the same error without reinvoking FetchFunc, until the
+// entry is removed via [Cache.Delete] or [Cache.Clear].
+//
+// For any given key, FetchFunc is invoked at most once per entry lifetime,
+// regardless of concurrent [Cache.Get] calls. Concurrent callers with the
+// same key block until the in-flight fetch completes, then all receive the
+// same (val, err) result.
+//
+// The ctx passed to FetchFunc is decorated with the source [Cache] and can
+// be retrieved via [FromContext]. Cancellation of ctx does not automatically
+// abort the fetch — FetchFunc should honor ctx.Done() internally if needed.
+//
+// FetchFunc should not call [Cache.Get] or [Cache.MaybeSet] on the same
+// [Cache] for the same key it was invoked for; doing so re-enters the
+// entry's [sync.Once] and deadlocks.
+//
+// If FetchFunc panics, the panic propagates to the triggering [Cache.Get]
+// call; the entry is recorded as "once"-consumed, and subsequent [Cache.Get]
+// calls return the zero value with a nil error, without reinvoking FetchFunc
+// (until the entry is explicitly evicted).
 type FetchFunc[K comparable, V any] func(ctx context.Context, key K) (val V, err error)
 
-// New returns a new [Cache] instance. The fetch func is invoked, on-demand, by
-// [Cache.Get] to obtain an entry value for a given key, OR the entry may be
-// externally set via [Cache.Set]. Either which way, the entry is populated only
-// once. That is, unless the entry is explicitly cleared via [Cache.Delete] or
-// [Cache.Clear], at which point the entry may be populated afresh.
+// New constructs a [Cache] parameterized over key type K and value type V. The
+// fetch func is invoked on-demand by [Cache.Get] to populate an entry for a
+// given key; alternatively, entries may be populated externally via
+// [Cache.MaybeSet]. Either way, each entry is populated only once, until it
+// is explicitly evicted via [Cache.Delete] or [Cache.Clear].
 //
-// Arg opts is a set of options that can be used to configure the cache. For
-// example, see [Name] to set the cache name, or the [OnFill] or [OnEvict]
-// options for event callbacks. Any nil [Opt] in opts is ignored.
+// Opts configures the cache:
+//   - [Name] sets the cache's display name (used by [Cache.String] and
+//     [Cache.LogValue]). If omitted, a random name like "cache-38a2b7d4" is
+//     generated.
+//   - [OnFill], [OnEvict], [OnHit], [OnMiss] register synchronous callbacks.
+//   - [OnEvent] configures channel-based async event delivery.
+//   - [Log] wires up a [slog.Logger] for basic logging.
+//
+// Nil [Opt] values in opts are ignored. Opts are applied in order; later opts
+// may override earlier ones (for [Name]), or add to them (for callbacks).
+//
+// The returned [Cache] is safe for concurrent use by multiple goroutines.
+//
+// Passing a nil fetch is permitted but limits the cache to [Cache.MaybeSet]
+// population: any [Cache.Get] for an unpopulated key will panic.
 func New[K comparable, V any](fetch FetchFunc[K, V], opts ...Opt) *Cache[K, V] {
 	c := &Cache[K, V]{
 		name:    randomName(),
@@ -42,6 +117,10 @@ func New[K comparable, V any](fetch FetchFunc[K, V], opts ...Opt) *Cache[K, V] {
 
 	c.applyOpts(opts)
 
+	// Fast-path selection: if no Get-emitted callbacks are registered, we can
+	// skip the callback-iteration bookkeeping inside once.Do. The fast/slow
+	// path is chosen once at construction time so Get/MaybeSet pay no
+	// per-call cost for deciding.
 	if len(c.onFill)+len(c.onMiss)+len(c.onHit) == 0 {
 		c.getValueFn = getValueFast[K, V]
 	} else {
@@ -57,93 +136,151 @@ func New[K comparable, V any](fetch FetchFunc[K, V], opts ...Opt) *Cache[K, V] {
 	return c
 }
 
-// applyOpts applies functional options.
+// applyOpts applies functional options to c.
+//
+// There are three dispatch paths, reflecting the three flavors of [Opt] in
+// this package:
+//
+//  1. [optApplier][K, V] — the common case. The opt knows the cache's
+//     K and V type parameters and can touch parameterized fields directly
+//     (e.g. the callback slices). Used by [OnFill], [OnEvict], [OnHit],
+//     [OnMiss], [OnEvent].
+//
+//  2. [concreteOptApplier] — opts that configure only non-parameterized
+//     fields. These cannot carry K/V and so receive a [concreteCache] view
+//     that exposes pointers to the non-parameterized state. Used by [Name].
+//
+//  3. [logOptConfig] — [Log] returns a non-parameterized value (so callers
+//     can write oncecache.Log(...) without spelling K and V). Here we
+//     reconstitute it as a typed logOpt[K, V] and apply it. This third
+//     branch is a known wart; see the review notes.
+//
+// Unrecognized Opt types panic to surface programmer errors early.
 func (c *Cache[K, V]) applyOpts(opts []Opt) {
 	for _, opt := range opts {
 		if isNil(opt) {
 			continue
 		}
 
-		// Most [Opt] types implement [optApplier]...
+		// 1. Type-parameterized opts.
 		if applier, ok := opt.(optApplier[K, V]); ok {
 			if _, ok = opt.(concreteOptApplier); ok {
-				// Sanity check.
+				// An Opt should implement exactly one of the two interfaces;
+				// implementing both means the dispatch below would be
+				// ambiguous.
 				panic(fmt.Sprintf("Opt type %T must not implement both optApplier and concreteOptApplier", opt))
 			}
 			applier.apply(c)
 			continue
 		}
 
-		// But, not all of them. Some of them implement [concreteOptApplier]. We
-		// must provide the non-parameterized (concrete) fields of [Cache].
+		// 2. Non-parameterized opts touching concrete fields only.
 		cc := &concreteCache{name: &c.name}
 		if applier, ok := opt.(concreteOptApplier); ok {
 			applier.applyConcrete(cc)
 			continue
 		}
 
-		// Hmmmn, I thought I was soooo clever with that applyConcrete mechanism,
-		// but it isn't helping with the logOpt scenario. Rethink required.
+		// 3. [Log]: reconstitute as logOpt[K, V] and apply.
 		if cfg, ok := opt.(logOptConfig); ok {
 			(*logOpt[K, V])(&cfg).apply(c)
 			continue
 		}
 
-		// Else, something went badly wrong.
 		panic(fmt.Sprintf("Invalid Opt type %T", opt))
 	}
 }
 
-// Cache is a concurrency-safe, in-memory, on-demand cache that ensures that a
+// Cache is a concurrency-safe, in-memory, on-demand cache that ensures a
 // given cache entry is populated only once, either implicitly via [Cache.Get]
-// and the fetch func, or externally via [Cache.Set].
+// (which invokes the [FetchFunc] supplied to [New]), or externally via
+// [Cache.MaybeSet]. A cache entry can be explicitly removed via [Cache.Delete]
+// or [Cache.Clear], after which it may be populated afresh.
 //
-// However, a cache entry can be explicitly cleared via [Cache.Delete] or
-// [Cache.Clear], allowing the entry to be populated afresh.
+// A cache entry is a (key, value, error) triple. An entry with a non-nil
+// error is still a valid, fully-populated entry: subsequent [Cache.Get] calls
+// return that error without reinvoking fetch. Entry population occurs only
+// once (hence "oncecache") unless the entry is evicted.
 //
-// A cache entry consists not only of the key and value, but also any error
-// associated with filling the entry value via the fetch func or via
-// [Cache.Set]. Thus, a cache entry is a triple: (key, value, error). An entry
-// with a non-nil error is still a valid cache entry. A call to [Cache.Get] for
-// an existing errorful cache entry does not invoke the fetch func again. Cache
-// entry population occurs only once (hence "oncecache"), unless the entry is
-// explicitly evicted via [Cache.Delete] or [Cache.Clear].
+// # Concurrency
 //
-// The zero value is not usable; instead invoke [New].
+// All methods are safe for concurrent use by multiple goroutines. For any
+// given key, the fetch func runs at most once per entry lifetime; concurrent
+// [Cache.Get] calls for an unfilled key block until the in-flight fetch
+// completes. Callbacks registered via [OnFill], [OnEvict], [OnHit], or
+// [OnMiss] run synchronously on the goroutine that triggered the event.
+//
+// # Not a general-purpose cache
+//
+// There is no TTL, no size bound, no background reaper, and no LRU eviction.
+// Memory grows monotonically as new keys are populated; callers manage
+// lifetime explicitly via [Cache.Delete] and [Cache.Clear].
+//
+// The zero value is not usable; construct a [Cache] via [New].
 type Cache[K comparable, V any] struct {
-	fetch           FetchFunc[K, V]
-	entries         map[K]*entry[K, V]
+	// fetch populates entries on Cache.Get when the key is absent.
+	fetch FetchFunc[K, V]
+
+	// entries holds the live cache map. Protected by mu for insertion,
+	// lookup, and deletion. The per-entry val/err fields are further
+	// protected by the entry's own sync.Once + filled flag; see entry's
+	// doc for the synchronization contract.
+	entries map[K]*entry[K, V]
+
+	// maybeSetValueFn and getValueFn are selected at construction time
+	// based on which callbacks are registered. The "fast" variants skip
+	// callback-iteration overhead when no relevant callbacks exist.
 	maybeSetValueFn func(ctx context.Context, e *entry[K, V], key K, val V, err error) bool
 	getValueFn      func(ctx context.Context, e *entry[K, V], key K) (V, error)
-	name            string
-	onFill          []callbackFunc[K, V]
-	onEvict         []callbackFunc[K, V]
-	onHit           []callbackFunc[K, V]
-	onMiss          []callbackFunc[K, V]
-	mu              sync.Mutex
+
+	// name is set via the Name opt, or a random value if not specified.
+	// Read-mostly after construction; may be overwritten by GobDecode.
+	name string
+
+	// on* slices are populated at construction time from opts and never
+	// mutated thereafter (except by Close, which nils them). Reading
+	// their length without the lock is therefore safe in the steady
+	// state.
+	onFill  []callbackFunc[K, V]
+	onEvict []callbackFunc[K, V]
+	onHit   []callbackFunc[K, V]
+	onMiss  []callbackFunc[K, V]
+
+	// mu guards entries and (transiently) name.
+	mu sync.Mutex
 }
 
-// Name returns the cache's name, useful for logging. Specify the cache name by
-// passing [oncecache.Name] to [New]; otherwise a random name is used.
+// Name returns the cache's name, useful in logs and debug output. The name
+// is set via the [Name] opt to [New]; otherwise a random name of the form
+// "cache-XXXXXXXX" (eight hex digits) is generated.
 func (c *Cache[K, V]) Name() string {
 	return c.name
 }
 
-// Len returns the number of entries in the cache.
+// Len returns the number of entries in the cache, including entries that
+// hold an error and entries whose fill is still in-flight. Safe for
+// concurrent use.
 func (c *Cache[K, V]) Len() int {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return len(c.entries)
 }
 
-// String returns a debug-friendly string representation of the cache.
+// String returns a debug-friendly string representation of the cache in the
+// form "<name>[<keyType>, <valType>][<len>]", e.g. "cache-foo[int, string][3]".
+// For structured logging, see [Cache.LogValue].
 func (c *Cache[K, V]) String() string {
 	return fmt.Sprintf("%s[%T, %T][%d]",
 		c.name, *new(K), *new(V), c.Len(),
 	)
 }
 
-// LogValue implements [slog.LogValuer].
+// LogValue implements [slog.LogValuer] for [slog.Logger] integration. The
+// emitted group contains:
+//   - name:    the cache name ([Cache.Name]).
+//   - entries: the current entry count ([Cache.Len]).
+//   - type:    a nested group with "key" and "val" fields naming the type
+//     parameters K and V.
 func (c *Cache[K, V]) LogValue() slog.Value {
 	return slog.GroupValue(
 		slog.String("name", c.name),
@@ -155,7 +292,9 @@ func (c *Cache[K, V]) LogValue() slog.Value {
 	)
 }
 
-// Has returns true if [Cache] c has an entry for key.
+// Has reports whether the cache contains an entry for key. An entry holding
+// a non-nil fill error, and an entry whose fill is still in-flight, both
+// count as present. Safe for concurrent use.
 func (c *Cache[K, V]) Has(key K) bool {
 	c.mu.Lock()
 	_, ok := c.entries[key]
@@ -163,7 +302,9 @@ func (c *Cache[K, V]) Has(key K) bool {
 	return ok
 }
 
-// Keys returns the cache keys. The keys will be in an indeterminate order.
+// Keys returns a snapshot of the cache's keys in indeterminate order.
+// Modifying the returned slice does not affect the cache. Safe for
+// concurrent use.
 func (c *Cache[K, V]) Keys() []K {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -178,6 +319,10 @@ func (c *Cache[K, V]) Keys() []K {
 // Clear clears the cache entries, invoking any [OnEvict] callbacks on each
 // cache entry. The entry callback order is not specified. The cache is locked
 // until Clear (including any callbacks) returns.
+//
+// If an entry is currently being filled when Clear is called, no [OnEvict]
+// callback is invoked for that entry; the in-flight fill is effectively
+// orphaned and its [OnFill] callbacks (if any) will still fire.
 func (c *Cache[K, V]) Clear(ctx context.Context) {
 	if len(c.onEvict) == 0 {
 		c.mu.Lock()
@@ -193,6 +338,9 @@ func (c *Cache[K, V]) Clear(ctx context.Context) {
 		if e == nil {
 			continue // Shouldn't be possible
 		}
+		if !e.filled.Load() {
+			continue
+		}
 
 		for _, fn := range e.cache.onEvict {
 			fn(ctx, key, e.val, e.err)
@@ -203,6 +351,10 @@ func (c *Cache[K, V]) Clear(ctx context.Context) {
 
 // Delete deletes the entry for the given key, invoking any [OnEvict] callbacks.
 // The cache is locked until Delete (including any callbacks) returns.
+//
+// If the entry is currently being filled when Delete is called, no [OnEvict]
+// callback is invoked; the in-flight fill is effectively orphaned and its
+// [OnFill] callbacks (if any) will still fire.
 func (c *Cache[K, V]) Delete(ctx context.Context, key K) {
 	if len(c.onEvict) == 0 {
 		c.mu.Lock()
@@ -219,6 +371,10 @@ func (c *Cache[K, V]) Delete(ctx context.Context, key K) {
 	}
 
 	delete(c.entries, key)
+	if !e.filled.Load() {
+		c.mu.Unlock()
+		return
+	}
 	ctx = NewContext(ctx, c)
 	for _, fn := range e.cache.onEvict {
 		fn(ctx, key, e.val, e.err)
@@ -226,30 +382,49 @@ func (c *Cache[K, V]) Delete(ctx context.Context, key K) {
 	c.mu.Unlock()
 }
 
-// MaybeSet sets the value and fill error for the given key if it is not already
-// filled, returning true if the value was set. This would allow an external
-// process to prime the cache.
+// MaybeSet sets the value and fill error for key if the entry is not already
+// filled, returning true if the value was set. This allows external code to
+// prime the cache or propagate values from another source.
 //
-// Note that the value might instead be filled implicitly via [Cache.Get], when
-// it invokes the fetch func. If there's already a cache entry for key, MaybeSet
-// is no-op: the value is not updated. If this MaybeSet call does update the
-// cache entry, any [OnFill] callbacks - as provided to [New] - are invoked, and
-// ok returns true.
+// If there's already an entry for key — whether it was populated by
+// [Cache.Get], a prior [Cache.MaybeSet], or even if it's still being filled
+// by an in-flight fetch — MaybeSet is a no-op and returns false. The err
+// argument, when non-nil, is stored alongside val just like a fetch error;
+// subsequent [Cache.Get] calls for this key return (val, err) without
+// reinvoking fetch.
+//
+// When MaybeSet does populate the entry, it invokes any [OnFill] callbacks
+// synchronously and emits an [OpFill] event via any [OnEvent] channels.
+// [OnMiss] is not emitted, since MaybeSet is not a [Cache.Get] miss.
 func (c *Cache[K, V]) MaybeSet(ctx context.Context, key K, val V, err error) (ok bool) {
 	e := c.getEntry(key)
 	return c.maybeSetValueFn(ctx, e, key, val, err)
 }
 
-// Get gets the value (and fill error) for the given key. If there's no entry
-// for the key, the fetch func is invoked, setting the entry value and error. If
-// the entry is already populated, the value and error are returned without
-// invoking the fetch func. Any [OnHit], [OnMiss], and [OnFill] callbacks are
-// invoked, and [OpHit], [OpMiss] and [OpFill] events emitted, as appropriate.
+// Get returns the cached value (and fill error) for key. On a cache miss,
+// the [FetchFunc] supplied to [New] is invoked to populate the entry, and
+// the resulting (val, err) is cached and returned. On a cache hit — including
+// an entry whose fill returned an error — the stored (val, err) is returned
+// directly without reinvoking fetch.
+//
+// Callback/event sequence:
+//   - Miss: [OnMiss] fires, fetch runs, then [OnFill] fires. [OpMiss] and
+//     [OpFill] events are emitted in that order.
+//   - Hit: [OnHit] fires; [OpHit] is emitted.
+//
+// Concurrent Get calls for the same unfilled key block until the in-flight
+// fetch completes and then all receive the same (val, err).
+//
+// If fetch panics, the panic propagates to this Get caller; see [FetchFunc]
+// for the post-panic entry state.
 func (c *Cache[K, V]) Get(ctx context.Context, key K) (V, error) {
 	e := c.getEntry(key)
 	return c.getValueFn(ctx, e, key)
 }
 
+// getEntry returns the entry for key, creating (but not yet populating) one
+// if it doesn't exist. The returned entry's val/err are zero until some
+// caller's once.Do completes. Holds c.mu only for the map lookup/insert.
 func (c *Cache[K, V]) getEntry(key K) *entry[K, V] {
 	c.mu.Lock()
 	e, ok := c.entries[key]
@@ -264,9 +439,24 @@ func (c *Cache[K, V]) getEntry(key K) *entry[K, V] {
 	return e
 }
 
-// Close closes the cache, releasing any resources. Close is idempotent and
-// always returns nil. Callbacks are not invoked. The cache is not usable after
-// Close is invoked; calls to other [Cache] methods may panic.
+// Close clears all entries and detaches all registered callbacks. It is
+// idempotent and always returns nil; it is also safe to call on a nil
+// [Cache] receiver, which is a no-op.
+//
+// After Close:
+//   - [Cache.Len] returns 0.
+//   - [Cache.Get] and [Cache.MaybeSet] still work, but no [OnFill],
+//     [OnMiss], [OnHit], or [OnEvict] callbacks will fire (they have been
+//     detached), and [OnEvent] channels no longer receive events for this
+//     cache.
+//   - Subsequent [Cache.Delete] and [Cache.Clear] succeed silently without
+//     firing [OnEvict].
+//
+// [OnEvict] is not invoked for the entries cleared by Close itself.
+//
+// Close is provided primarily to release callback references (useful when
+// callbacks close over large objects) and to empty the cache in one call;
+// it does not mark the cache as permanently closed.
 func (c *Cache[K, V]) Close() error {
 	if c == nil {
 		return nil
@@ -283,23 +473,33 @@ func (c *Cache[K, V]) Close() error {
 	return nil
 }
 
+// Compile-time assertion that [Cache] satisfies the gob encoder/decoder
+// contract. The concrete type parameterization is immaterial; gob cares
+// only about the method set.
 var (
 	_ gob.GobEncoder = (*Cache[int, int])(nil)
 	_ gob.GobDecoder = (*Cache[int, int])(nil)
 )
 
+// gobData is the on-wire representation of a [Cache]. Only the cache name
+// and its filled entries are serialized; the fetch func and callbacks are
+// not.
 type gobData[K comparable, V any] struct {
 	Entries map[K]*gobEntry[K, V]
 	Name    string
 }
 
+// gobEntry is the on-wire representation of a single cache entry: just the
+// value and fill error. The sync.Once and filled flag are reconstructed on
+// decode.
 type gobEntry[K comparable, V any] struct {
 	Val V
 	Err error
 }
 
 // GobEncode implements [gob.GobEncoder]. Only the cache name and entries are
-// encoded. The fetch func and callbacks are not encoded.
+// encoded. The fetch func and callbacks are not encoded. Entries whose fill is
+// still in-flight are omitted from the encoded output.
 func (c *Cache[K, V]) GobEncode() ([]byte, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -310,6 +510,9 @@ func (c *Cache[K, V]) GobEncode() ([]byte, error) {
 	}
 
 	for k, ent := range c.entries {
+		if !ent.filled.Load() {
+			continue
+		}
 		gbd.Entries[k] = &gobEntry[K, V]{Val: ent.val, Err: ent.err}
 	}
 
@@ -322,8 +525,16 @@ func (c *Cache[K, V]) GobEncode() ([]byte, error) {
 }
 
 // GobDecode implements [gob.GobDecoder]. Only the cache name and entries are
-// decoded. The fetch func and callbacks are not decoded. Any pre-existing
-// entries in c are cleared prior to decoding.
+// restored from p; the fetch func and callbacks on c are preserved as-is.
+// Any pre-existing entries in c are cleared before decoding; decoded entries
+// are marked as filled, so subsequent [Cache.Get] calls return them directly
+// without invoking fetch.
+//
+// The error type(s) used in entries with non-nil fill errors must be
+// registered with [gob.Register] before encoding/decoding.
+//
+// GobDecode does not fire [OnEvict] for the pre-existing entries it clears,
+// nor [OnFill] for the decoded entries it installs.
 func (c *Cache[K, V]) GobDecode(p []byte) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -338,6 +549,7 @@ func (c *Cache[K, V]) GobDecode(p []byte) error {
 	for k, e := range gbd.Entries {
 		ent := &entry[K, V]{val: e.Val, err: e.Err, cache: c}
 		ent.once.Do(func() {}) // Consume the sync.Once
+		ent.filled.Store(true)
 		c.entries[k] = ent
 	}
 
@@ -346,19 +558,29 @@ func (c *Cache[K, V]) GobDecode(p []byte) error {
 
 // entry is the internal representation of a cache entry. Contrast with the
 // external [Entry] type.
+//
+// Fields val and err are written exactly once, inside once.Do, and must not be
+// read by any code path that doesn't either run inside once.Do or observe
+// filled.Load() == true. This ordering lets external readers (Delete, Clear,
+// GobEncode) skip entries whose fill is still in-flight, avoiding a race with
+// the filling goroutine.
 type entry[K comparable, V any] struct {
-	val   V
-	err   error
-	cache *Cache[K, V]
-	once  sync.Once
+	val    V
+	err    error
+	cache  *Cache[K, V]
+	once   sync.Once
+	filled atomic.Bool
 }
 
+// maybeSetValueSlow is the MaybeSet core used when OnFill callbacks are
+// registered. See maybeSetValueFast for the no-callback path.
 func maybeSetValueSlow[K comparable, V any](ctx context.Context, e *entry[K, V], key K, val V, err error) bool {
 	var ok bool
 	e.once.Do(func() {
 		ok = true
 		e.val = val
 		e.err = err
+		e.filled.Store(true)
 		ctx = NewContext(ctx, e.cache)
 		for _, fn := range e.cache.onFill {
 			fn(ctx, key, val, err)
@@ -367,16 +589,24 @@ func maybeSetValueSlow[K comparable, V any](ctx context.Context, e *entry[K, V],
 	return ok
 }
 
+// maybeSetValueFast is the MaybeSet core used when no OnFill callbacks are
+// registered. It skips callback iteration and the NewContext decoration.
 func maybeSetValueFast[K comparable, V any](_ context.Context, e *entry[K, V], _ K, val V, err error) bool {
 	var ok bool
 	e.once.Do(func() {
 		e.val = val
 		e.err = err
+		e.filled.Store(true)
 		ok = true
 	})
 	return ok
 }
 
+// getValueSlow is the Get core used when any of the Get-triggered callbacks
+// (OnMiss, OnFill, OnHit) are registered. On miss it fires OnMiss, runs
+// fetch, marks the entry filled, then fires OnFill — all inside the entry's
+// sync.Once. On hit it fires OnHit outside the Once (safe: the Once's
+// completion synchronizes the val/err writes for later readers).
 func getValueSlow[K comparable, V any](ctx context.Context, e *entry[K, V], key K) (V, error) {
 	var miss bool
 	e.once.Do(func() {
@@ -387,6 +617,7 @@ func getValueSlow[K comparable, V any](ctx context.Context, e *entry[K, V], key 
 		}
 
 		e.val, e.err = e.cache.fetch(ctx, key)
+		e.filled.Store(true)
 
 		for _, fn := range e.cache.onFill {
 			fn(ctx, key, e.val, e.err)
@@ -403,19 +634,31 @@ func getValueSlow[K comparable, V any](ctx context.Context, e *entry[K, V], key 
 	return e.val, e.err
 }
 
+// getValueFast is the Get core used when no Get-triggered callbacks are
+// registered, which is the common case. It skips the OnMiss/OnFill/OnHit
+// iteration entirely.
 func getValueFast[K comparable, V any](ctx context.Context, e *entry[K, V], key K) (V, error) {
 	e.once.Do(func() {
 		ctx = NewContext(ctx, e.cache)
 		e.val, e.err = e.cache.fetch(ctx, key)
+		e.filled.Store(true)
 	})
 
 	return e.val, e.err
 }
 
+// ctxKey is the unexported context key under which cache instances are
+// stored by [NewContext] and retrieved by [FromContext].
 type ctxKey struct{}
 
-// NewContext returns ctx decorated with [Cache] c. If ctx is nil, a new context
-// is created.
+// NewContext returns ctx decorated with [Cache] c. If ctx is nil, a fresh
+// [context.Background] is used as the parent.
+//
+// This is the mechanism by which fetch and callback invocations receive
+// access to their source [Cache]: Cache itself calls NewContext before
+// dispatching fetch or callbacks, and user code retrieves the cache via
+// [FromContext]. Callers seldom need to invoke NewContext directly except
+// in tests or to build a ctx carrying a specific cache for downstream code.
 func NewContext[K comparable, V any](ctx context.Context, c *Cache[K, V]) context.Context {
 	if ctx == nil {
 		ctx = context.Background()
@@ -424,9 +667,12 @@ func NewContext[K comparable, V any](ctx context.Context, c *Cache[K, V]) contex
 	return context.WithValue(ctx, ctxKey{}, c)
 }
 
-// FromContext returns the [Cache] value stored in ctx, if any, or nil. All
-// cache callbacks receive a context that has been decorated with the [Cache]
-// instance.
+// FromContext returns the [Cache] previously stored in ctx by [NewContext],
+// or nil if ctx is nil, has no cache value, or the stored cache is
+// parameterized with different K/V types than requested.
+//
+// Use this inside a [FetchFunc] or synchronous callback to access the source
+// cache without closing over it at construction time.
 func FromContext[K comparable, V any](ctx context.Context) *Cache[K, V] {
 	if ctx == nil {
 		return nil
@@ -444,20 +690,30 @@ func FromContext[K comparable, V any](ctx context.Context) *Cache[K, V] {
 	return nil
 }
 
+// randomName returns a default cache name of the form "cache-XXXXXXXX" where
+// X is a hex digit. The value is drawn from crypto/rand and hashed via
+// CRC-32 to produce a short, roughly-unique identifier suitable for logs.
+// It is not intended to be cryptographically secure — collisions across
+// many caches are acceptable since names are only used for display.
 func randomName() string {
 	b := make([]byte, 128)
 	_, _ = rand.Read(b)
 	return fmt.Sprintf("cache-%x", crc32.ChecksumIEEE(b))
 }
 
-// isNil checks if a value is nil or if it's a reference type with a nil
-// underlying value.
+// isNil reports whether x is nil, or whether x is a typed-nil reference
+// type (pointer, channel, func, interface, map, slice). The deferred
+// recover guards against reflect.Value.IsNil panicking on non-nilable
+// kinds (e.g. struct, int): for those kinds we want to return false, which
+// is the value already initialized in the named return after the panic.
 func isNil(x any) bool {
 	defer func() { recover() }() //nolint:errcheck
 	return x == nil || reflect.ValueOf(x).IsNil()
 }
 
-// uniq returns a new slice containing only the unique elements of a.
+// uniq returns a new slice containing the elements of a in their original
+// order, with duplicates removed. Used to normalize user-supplied op lists
+// in [OnEvent] and [Log].
 func uniq[T comparable](a []T) []T {
 	result := make([]T, 0, len(a))
 	seen := make(map[T]struct{}, len(a))

--- a/oncecache.go
+++ b/oncecache.go
@@ -394,12 +394,15 @@ func (c *Cache[K, V]) Delete(ctx context.Context, key K) {
 // filled, returning true if the value was set. This allows external code to
 // prime the cache or propagate values from another source.
 //
-// If there's already an entry for key — whether it was populated by
-// [Cache.Get], a prior [Cache.MaybeSet], or even if it's still being filled
-// by an in-flight fetch — MaybeSet is a no-op and returns false. The err
-// argument, when non-nil, is stored alongside val just like a fetch error;
-// subsequent [Cache.Get] calls for this key return (val, err) without
-// reinvoking fetch.
+// If there's already a filled entry for key — populated by a prior
+// [Cache.Get] or [Cache.MaybeSet] — MaybeSet does not replace it and
+// returns false. If the entry is still being filled by an in-flight
+// fetch, MaybeSet blocks until that fetch completes (because it shares
+// the entry's [sync.Once]), and then returns false.
+//
+// The err argument, when non-nil, is stored alongside val just like a
+// fetch error; subsequent [Cache.Get] calls for this key return
+// (val, err) without reinvoking fetch.
 //
 // When MaybeSet does populate the entry, it invokes any [OnFill] callbacks
 // synchronously and emits an [OpFill] event via any [OnEvent] channels.
@@ -521,18 +524,21 @@ func (c *Cache[K, V]) GobEncode() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// GobDecode implements [gob.GobDecoder]. Only the cache name and entries are
-// restored from p; the fetch func and callbacks on c are preserved as-is.
-// Any pre-existing entries in c are cleared before decoding; decoded entries
-// are marked as filled, so subsequent [Cache.Get] calls return them directly
-// without invoking fetch.
+// GobDecode implements [gob.GobDecoder]. Only the cache name and entries
+// are restored from p. Any pre-existing entries in c are cleared before
+// decoding; decoded entries are marked as filled, so subsequent
+// [Cache.Get] calls return them directly without invoking fetch.
 //
-// Unlike other methods, GobDecode is safe to call on a zero-value [Cache]
-// (as gob-provided decoding into `var c Cache[K, V]` will do): it
-// initializes the internal map and dispatch functions on demand. The
-// decoded cache will have no fetch func and no callbacks, so further
-// [Cache.Get] for a key not already in the decoded map yields an error
-// wrapping [ErrPanic] (the recovered nil-fetch call).
+// Behavior depends on how c was initialized:
+//   - Decoding into a [Cache] constructed via [New]: the existing fetch
+//     func and callbacks are preserved. [Cache.Get] on a key absent from
+//     the decoded payload triggers the existing fetch func as usual.
+//   - Decoding into a zero-value [Cache] (as `gob.Decode` into
+//     `var c Cache[K, V]` does): the internal map and dispatch functions
+//     are initialized on demand, but the cache has no fetch func and no
+//     callbacks. [Cache.Get] for a key absent from the decoded payload
+//     yields an error wrapping [ErrPanic] (the recovered nil-fetch
+//     dereference).
 //
 // The error type(s) used in entries with non-nil fill errors must be
 // registered with [gob.Register] before encoding/decoding. The package

--- a/oncecache.go
+++ b/oncecache.go
@@ -51,14 +51,12 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/gob"
+	"errors"
 	"fmt"
-	"hash/crc32"
 	"log/slog"
 	"reflect"
 	"sync"
 	"sync/atomic"
-
-	"golang.org/x/exp/maps"
 )
 
 // FetchFunc is called by [Cache.Get] to fill an unpopulated cache entry. It
@@ -81,11 +79,23 @@ import (
 // [Cache] for the same key it was invoked for; doing so re-enters the
 // entry's [sync.Once] and deadlocks.
 //
-// If FetchFunc panics, the panic propagates to the triggering [Cache.Get]
-// call; the entry is recorded as "once"-consumed, and subsequent [Cache.Get]
-// calls return the zero value with a nil error, without reinvoking FetchFunc
-// (until the entry is explicitly evicted).
+// If FetchFunc panics, the cache recovers the panic and stores it as the
+// entry's fill error, wrapped so [errors.Is] matches [ErrPanic]. The
+// triggering [Cache.Get] call returns the zero value together with that
+// wrapped error rather than propagating the panic. Subsequent [Cache.Get]
+// calls for the same key return the same wrapped error, without
+// reinvoking FetchFunc, until the entry is evicted. The [OnFill] callbacks
+// fire normally with the wrapped error. This preserves the lifecycle
+// invariant: a miss is followed by a fill — successful or panic-wrapped.
 type FetchFunc[K comparable, V any] func(ctx context.Context, key K) (val V, err error)
+
+// ErrPanic is the sentinel wrapped in the fill error when a [FetchFunc]
+// panics. Use [errors.Is] to detect it:
+//
+//	if _, err := c.Get(ctx, key); errors.Is(err, oncecache.ErrPanic) {
+//		// ... handle panic-during-fetch
+//	}
+var ErrPanic = errors.New("oncecache: panic in FetchFunc")
 
 // New constructs a [Cache] parameterized over key type K and value type V. The
 // fetch func is invoked on-demand by [Cache.Get] to populate an entry for a
@@ -110,10 +120,11 @@ type FetchFunc[K comparable, V any] func(ctx context.Context, key K) (val V, err
 // population: any [Cache.Get] for an unpopulated key will panic.
 func New[K comparable, V any](fetch FetchFunc[K, V], opts ...Opt) *Cache[K, V] {
 	c := &Cache[K, V]{
-		name:    randomName(),
 		entries: map[K]*entry[K, V]{},
 		fetch:   fetch,
 	}
+	defaultName := randomName()
+	c.name.Store(&defaultName)
 
 	c.applyOpts(opts)
 
@@ -136,58 +147,36 @@ func New[K comparable, V any](fetch FetchFunc[K, V], opts ...Opt) *Cache[K, V] {
 	return c
 }
 
-// applyOpts applies functional options to c.
+// applyOpts applies functional options to c. It dispatches on the dynamic
+// type of each [Opt]:
 //
-// There are three dispatch paths, reflecting the three flavors of [Opt] in
-// this package:
+//   - [Name] sets the cache's display name directly.
+//   - [logOptConfig] (returned by [Log]) is a non-parameterized payload
+//     that we reconstitute as a typed logOpt[K, V] before applying.
+//   - Anything else must satisfy [optApplier][K, V] — a generic-aware
+//     applier used by [OnFill], [OnEvict], [OnHit], [OnMiss], and
+//     [OnEvent], all of which can touch the cache's parameterized fields
+//     (callback slices) directly.
 //
-//  1. [optApplier][K, V] — the common case. The opt knows the cache's
-//     K and V type parameters and can touch parameterized fields directly
-//     (e.g. the callback slices). Used by [OnFill], [OnEvict], [OnHit],
-//     [OnMiss], [OnEvent].
-//
-//  2. [concreteOptApplier] — opts that configure only non-parameterized
-//     fields. These cannot carry K/V and so receive a [concreteCache] view
-//     that exposes pointers to the non-parameterized state. Used by [Name].
-//
-//  3. [logOptConfig] — [Log] returns a non-parameterized value (so callers
-//     can write oncecache.Log(...) without spelling K and V). Here we
-//     reconstitute it as a typed logOpt[K, V] and apply it. This third
-//     branch is a known wart; see the review notes.
-//
-// Unrecognized Opt types panic to surface programmer errors early.
+// Unrecognized Opt types panic to surface programmer errors early. The
+// [Opt] interface is closed (its marker method is unexported), so any
+// reachable Opt is necessarily one of the kinds above.
 func (c *Cache[K, V]) applyOpts(opts []Opt) {
 	for _, opt := range opts {
 		if isNil(opt) {
 			continue
 		}
-
-		// 1. Type-parameterized opts.
-		if applier, ok := opt.(optApplier[K, V]); ok {
-			if _, ok = opt.(concreteOptApplier); ok {
-				// An Opt should implement exactly one of the two interfaces;
-				// implementing both means the dispatch below would be
-				// ambiguous.
-				panic(fmt.Sprintf("Opt type %T must not implement both optApplier and concreteOptApplier", opt))
-			}
-			applier.apply(c)
-			continue
+		switch o := opt.(type) {
+		case Name:
+			s := string(o)
+			c.name.Store(&s)
+		case logOptConfig:
+			(*logOpt[K, V])(&o).apply(c)
+		case optApplier[K, V]:
+			o.apply(c)
+		default:
+			panic(fmt.Sprintf("Invalid Opt type %T", opt))
 		}
-
-		// 2. Non-parameterized opts touching concrete fields only.
-		cc := &concreteCache{name: &c.name}
-		if applier, ok := opt.(concreteOptApplier); ok {
-			applier.applyConcrete(cc)
-			continue
-		}
-
-		// 3. [Log]: reconstitute as logOpt[K, V] and apply.
-		if cfg, ok := opt.(logOptConfig); ok {
-			(*logOpt[K, V])(&cfg).apply(c)
-			continue
-		}
-
-		panic(fmt.Sprintf("Invalid Opt type %T", opt))
 	}
 }
 
@@ -229,18 +218,20 @@ type Cache[K comparable, V any] struct {
 
 	// maybeSetValueFn and getValueFn are selected at construction time
 	// based on which callbacks are registered. The "fast" variants skip
-	// callback-iteration overhead when no relevant callbacks exist.
-	maybeSetValueFn func(ctx context.Context, e *entry[K, V], key K, val V, err error) bool
-	getValueFn      func(ctx context.Context, e *entry[K, V], key K) (V, error)
+	// callback-iteration overhead when no relevant callbacks exist. The
+	// cache is passed as the first argument rather than stored on each
+	// entry, saving one pointer per entry.
+	maybeSetValueFn func(c *Cache[K, V], ctx context.Context, e *entry[K, V], key K, val V, err error) bool
+	getValueFn      func(c *Cache[K, V], ctx context.Context, e *entry[K, V], key K) (V, error)
 
 	// name is set via the Name opt, or a random value if not specified.
-	// Read-mostly after construction; may be overwritten by GobDecode.
-	name string
+	// Stored as atomic.Pointer[string] so [Cache.Name] / [Cache.String] /
+	// [Cache.LogValue] can safely read it without c.mu, even concurrently
+	// with [Cache.GobDecode] (which overwrites it).
+	name atomic.Pointer[string]
 
-	// on* slices are populated at construction time from opts and never
-	// mutated thereafter (except by Close, which nils them). Reading
-	// their length without the lock is therefore safe in the steady
-	// state.
+	// on* slices are populated at construction time from opts and are
+	// never mutated thereafter, so they may be read without the lock.
 	onFill  []callbackFunc[K, V]
 	onEvict []callbackFunc[K, V]
 	onHit   []callbackFunc[K, V]
@@ -252,9 +243,10 @@ type Cache[K comparable, V any] struct {
 
 // Name returns the cache's name, useful in logs and debug output. The name
 // is set via the [Name] opt to [New]; otherwise a random name of the form
-// "cache-XXXXXXXX" (eight hex digits) is generated.
+// "cache-XXXXXXXX" (eight hex digits) is generated. Safe for concurrent
+// use, including with [Cache.GobDecode].
 func (c *Cache[K, V]) Name() string {
-	return c.name
+	return *c.name.Load()
 }
 
 // Len returns the number of entries in the cache, including entries that
@@ -271,7 +263,7 @@ func (c *Cache[K, V]) Len() int {
 // For structured logging, see [Cache.LogValue].
 func (c *Cache[K, V]) String() string {
 	return fmt.Sprintf("%s[%T, %T][%d]",
-		c.name, *new(K), *new(V), c.Len(),
+		c.Name(), *new(K), *new(V), c.Len(),
 	)
 }
 
@@ -283,7 +275,7 @@ func (c *Cache[K, V]) String() string {
 //     parameters K and V.
 func (c *Cache[K, V]) LogValue() slog.Value {
 	return slog.GroupValue(
-		slog.String("name", c.name),
+		slog.String("name", c.Name()),
 		slog.Int("entries", c.Len()),
 		slog.Group("type",
 			"key", fmt.Sprintf("%T", *new(K)),
@@ -316,70 +308,75 @@ func (c *Cache[K, V]) Keys() []K {
 	return r
 }
 
-// Clear clears the cache entries, invoking any [OnEvict] callbacks on each
-// cache entry. The entry callback order is not specified. The cache is locked
-// until Clear (including any callbacks) returns.
+// Clear empties the cache, invoking any [OnEvict] callbacks once per
+// previously-filled entry. The eviction callback order is not specified.
+//
+// Callbacks fire after c.mu has been released, so a callback may safely
+// call methods on the same cache (including [Cache.Get], [Cache.Delete],
+// [Cache.Has], etc.) without deadlocking.
 //
 // If an entry is currently being filled when Clear is called, no [OnEvict]
 // callback is invoked for that entry; the in-flight fill is effectively
-// orphaned and its [OnFill] callbacks (if any) will still fire.
+// orphaned and its [OnFill] callbacks (if any) will still fire when fetch
+// completes (against an entry no longer in the cache).
 func (c *Cache[K, V]) Clear(ctx context.Context) {
+	c.mu.Lock()
 	if len(c.onEvict) == 0 {
-		c.mu.Lock()
 		clear(c.entries)
 		c.mu.Unlock()
 		return
 	}
 
-	ctx = NewContext(ctx, c)
-	c.mu.Lock()
-	for key, e := range c.entries {
-		delete(c.entries, key)
-		if e == nil {
-			continue // Shouldn't be possible
-		}
-		if !e.filled.Load() {
-			continue
-		}
-
-		for _, fn := range e.cache.onEvict {
-			fn(ctx, key, e.val, e.err)
+	// Snapshot the keys + filled entries under the lock, then release the
+	// lock before invoking callbacks. This avoids deadlocking when a
+	// callback re-enters the same cache.
+	type kv struct {
+		key K
+		e   *entry[K, V]
+	}
+	snap := make([]kv, 0, len(c.entries))
+	for k, e := range c.entries {
+		if e.filled.Load() {
+			snap = append(snap, kv{key: k, e: e})
 		}
 	}
+	clear(c.entries)
 	c.mu.Unlock()
+
+	cbCtx := NewContext(ctx, c)
+	for _, item := range snap {
+		for _, fn := range c.onEvict {
+			fn(cbCtx, item.key, item.e.val, item.e.err)
+		}
+	}
 }
 
-// Delete deletes the entry for the given key, invoking any [OnEvict] callbacks.
-// The cache is locked until Delete (including any callbacks) returns.
+// Delete removes the entry for key, invoking any [OnEvict] callbacks if the
+// entry was filled. Delete is a no-op if the key is not present.
 //
-// If the entry is currently being filled when Delete is called, no [OnEvict]
-// callback is invoked; the in-flight fill is effectively orphaned and its
-// [OnFill] callbacks (if any) will still fire.
+// Callbacks fire after c.mu has been released, so a callback may safely
+// call methods on the same cache without deadlocking.
+//
+// If the entry is currently being filled when Delete is called, no
+// [OnEvict] callback is invoked; the in-flight fill is effectively
+// orphaned and its [OnFill] callbacks (if any) will still fire.
 func (c *Cache[K, V]) Delete(ctx context.Context, key K) {
-	if len(c.onEvict) == 0 {
-		c.mu.Lock()
-		delete(c.entries, key)
-		c.mu.Unlock()
-		return
-	}
-
 	c.mu.Lock()
 	e, ok := c.entries[key]
 	if !ok {
 		c.mu.Unlock()
 		return
 	}
-
 	delete(c.entries, key)
-	if !e.filled.Load() {
-		c.mu.Unlock()
+	c.mu.Unlock()
+
+	if len(c.onEvict) == 0 || !e.filled.Load() {
 		return
 	}
-	ctx = NewContext(ctx, c)
-	for _, fn := range e.cache.onEvict {
-		fn(ctx, key, e.val, e.err)
+	cbCtx := NewContext(ctx, c)
+	for _, fn := range c.onEvict {
+		fn(cbCtx, key, e.val, e.err)
 	}
-	c.mu.Unlock()
 }
 
 // MaybeSet sets the value and fill error for key if the entry is not already
@@ -398,7 +395,7 @@ func (c *Cache[K, V]) Delete(ctx context.Context, key K) {
 // [OnMiss] is not emitted, since MaybeSet is not a [Cache.Get] miss.
 func (c *Cache[K, V]) MaybeSet(ctx context.Context, key K, val V, err error) (ok bool) {
 	e := c.getEntry(key)
-	return c.maybeSetValueFn(ctx, e, key, val, err)
+	return c.maybeSetValueFn(c, ctx, e, key, val, err)
 }
 
 // Get returns the cached value (and fill error) for key. On a cache miss,
@@ -419,7 +416,7 @@ func (c *Cache[K, V]) MaybeSet(ctx context.Context, key K, val V, err error) (ok
 // for the post-panic entry state.
 func (c *Cache[K, V]) Get(ctx context.Context, key K) (V, error) {
 	e := c.getEntry(key)
-	return c.getValueFn(ctx, e, key)
+	return c.getValueFn(c, ctx, e, key)
 }
 
 // getEntry returns the entry for key, creating (but not yet populating) one
@@ -433,43 +430,29 @@ func (c *Cache[K, V]) getEntry(key K) *entry[K, V] {
 		return e
 	}
 
-	e = &entry[K, V]{cache: c}
+	e = &entry[K, V]{}
 	c.entries[key] = e
 	c.mu.Unlock()
 	return e
 }
 
-// Close clears all entries and detaches all registered callbacks. It is
-// idempotent and always returns nil; it is also safe to call on a nil
-// [Cache] receiver, which is a no-op.
+// Close empties the cache. It is idempotent, always returns nil, and is
+// safe to call on a nil [Cache] receiver (no-op) and concurrently with
+// other [Cache] methods.
 //
-// After Close:
-//   - [Cache.Len] returns 0.
-//   - [Cache.Get] and [Cache.MaybeSet] still work, but no [OnFill],
-//     [OnMiss], [OnHit], or [OnEvict] callbacks will fire (they have been
-//     detached), and [OnEvent] channels no longer receive events for this
-//     cache.
-//   - Subsequent [Cache.Delete] and [Cache.Clear] succeed silently without
-//     firing [OnEvict].
-//
-// [OnEvict] is not invoked for the entries cleared by Close itself.
-//
-// Close is provided primarily to release callback references (useful when
-// callbacks close over large objects) and to empty the cache in one call;
-// it does not mark the cache as permanently closed.
+// Close does not invoke [OnEvict] for the entries it clears, and it does
+// not detach callbacks: the cache remains fully usable afterwards. Close
+// is essentially a no-eviction-callback variant of [Cache.Clear], provided
+// so [Cache] satisfies [io.Closer]. Callers that wish to release memory
+// referenced by callback closures should drop their reference to the
+// cache so it can be GC'd.
 func (c *Cache[K, V]) Close() error {
 	if c == nil {
 		return nil
 	}
-
 	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	c.onFill = nil
-	c.onEvict = nil
-	c.onHit = nil
-	c.onMiss = nil
 	clear(c.entries)
+	c.mu.Unlock()
 	return nil
 }
 
@@ -505,7 +488,7 @@ func (c *Cache[K, V]) GobEncode() ([]byte, error) {
 	defer c.mu.Unlock()
 
 	gbd := &gobData[K, V]{
-		Name:    c.name,
+		Name:    *c.name.Load(),
 		Entries: make(map[K]*gobEntry[K, V], len(c.entries)),
 	}
 
@@ -544,10 +527,11 @@ func (c *Cache[K, V]) GobDecode(p []byte) error {
 		return err
 	}
 
-	c.name = gbd.Name
-	maps.Clear(c.entries)
+	name := gbd.Name
+	c.name.Store(&name)
+	clear(c.entries)
 	for k, e := range gbd.Entries {
-		ent := &entry[K, V]{val: e.Val, err: e.Err, cache: c}
+		ent := &entry[K, V]{val: e.Val, err: e.Err}
 		ent.once.Do(func() {}) // Consume the sync.Once
 		ent.filled.Store(true)
 		c.entries[k] = ent
@@ -559,31 +543,61 @@ func (c *Cache[K, V]) GobDecode(p []byte) error {
 // entry is the internal representation of a cache entry. Contrast with the
 // external [Entry] type.
 //
-// Fields val and err are written exactly once, inside once.Do, and must not be
-// read by any code path that doesn't either run inside once.Do or observe
-// filled.Load() == true. This ordering lets external readers (Delete, Clear,
-// GobEncode) skip entries whose fill is still in-flight, avoiding a race with
-// the filling goroutine.
+// Fields val and err are written exactly once, inside once.Do, and must not
+// be read by any code path that doesn't either run inside once.Do or observe
+// filled.Load() == true. This ordering lets external readers ([Cache.Delete],
+// [Cache.Clear], [Cache.GobEncode]) skip entries whose fill is still
+// in-flight, avoiding a race with the filling goroutine.
+//
+// The entry does not hold a back-pointer to its source [Cache]; fill helpers
+// receive the cache as a parameter instead.
 type entry[K comparable, V any] struct {
 	val    V
 	err    error
-	cache  *Cache[K, V]
 	once   sync.Once
 	filled atomic.Bool
 }
 
+// fillPanic wraps a recovered panic value into an error that can be stored
+// in a cache entry. It unwraps to [ErrPanic] so callers can test via
+// [errors.Is].
+type fillPanic struct {
+	recovered any
+}
+
+func (p *fillPanic) Error() string { return fmt.Sprintf("%s: %v", ErrPanic, p.recovered) }
+func (p *fillPanic) Unwrap() error { return ErrPanic }
+
+// callFetch invokes c.fetch, recovering any panic and converting it into
+// an error wrapping [ErrPanic]. The recovered panic is NOT re-thrown:
+// returning the wrapped error is more useful than propagating the panic to
+// the caller, and it avoids leaving the entry in a half-initialized state.
+//
+// Callback panics (OnMiss, OnFill, OnHit, OnEvict) are deliberately not
+// recovered here; they propagate to the triggering caller.
+func callFetch[K comparable, V any](c *Cache[K, V], ctx context.Context, key K) (val V, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			var zero V
+			val = zero
+			err = &fillPanic{recovered: r}
+		}
+	}()
+	return c.fetch(ctx, key)
+}
+
 // maybeSetValueSlow is the MaybeSet core used when OnFill callbacks are
 // registered. See maybeSetValueFast for the no-callback path.
-func maybeSetValueSlow[K comparable, V any](ctx context.Context, e *entry[K, V], key K, val V, err error) bool {
+func maybeSetValueSlow[K comparable, V any](c *Cache[K, V], ctx context.Context, e *entry[K, V], key K, val V, err error) bool {
 	var ok bool
 	e.once.Do(func() {
 		ok = true
 		e.val = val
 		e.err = err
 		e.filled.Store(true)
-		ctx = NewContext(ctx, e.cache)
-		for _, fn := range e.cache.onFill {
-			fn(ctx, key, val, err)
+		cbCtx := NewContext(ctx, c)
+		for _, fn := range c.onFill {
+			fn(cbCtx, key, val, err)
 		}
 	})
 	return ok
@@ -591,7 +605,7 @@ func maybeSetValueSlow[K comparable, V any](ctx context.Context, e *entry[K, V],
 
 // maybeSetValueFast is the MaybeSet core used when no OnFill callbacks are
 // registered. It skips callback iteration and the NewContext decoration.
-func maybeSetValueFast[K comparable, V any](_ context.Context, e *entry[K, V], _ K, val V, err error) bool {
+func maybeSetValueFast[K comparable, V any](_ *Cache[K, V], _ context.Context, e *entry[K, V], _ K, val V, err error) bool {
 	var ok bool
 	e.once.Do(func() {
 		e.val = val
@@ -604,30 +618,31 @@ func maybeSetValueFast[K comparable, V any](_ context.Context, e *entry[K, V], _
 
 // getValueSlow is the Get core used when any of the Get-triggered callbacks
 // (OnMiss, OnFill, OnHit) are registered. On miss it fires OnMiss, runs
-// fetch, marks the entry filled, then fires OnFill — all inside the entry's
-// sync.Once. On hit it fires OnHit outside the Once (safe: the Once's
-// completion synchronizes the val/err writes for later readers).
-func getValueSlow[K comparable, V any](ctx context.Context, e *entry[K, V], key K) (V, error) {
+// fetch (with panic recovery), marks the entry filled, then fires OnFill —
+// all inside the entry's sync.Once. On hit it fires OnHit outside the Once
+// (safe: the Once's completion synchronizes the val/err writes for later
+// readers).
+func getValueSlow[K comparable, V any](c *Cache[K, V], ctx context.Context, e *entry[K, V], key K) (V, error) {
 	var miss bool
 	e.once.Do(func() {
 		miss = true
-		ctx = NewContext(ctx, e.cache)
-		for _, fn := range e.cache.onMiss {
-			fn(ctx, key, e.val, e.err)
+		cbCtx := NewContext(ctx, c)
+		for _, fn := range c.onMiss {
+			fn(cbCtx, key, e.val, e.err)
 		}
 
-		e.val, e.err = e.cache.fetch(ctx, key)
+		e.val, e.err = callFetch(c, cbCtx, key)
 		e.filled.Store(true)
 
-		for _, fn := range e.cache.onFill {
-			fn(ctx, key, e.val, e.err)
+		for _, fn := range c.onFill {
+			fn(cbCtx, key, e.val, e.err)
 		}
 	})
 
-	if !miss && len(e.cache.onHit) > 0 {
-		ctx = NewContext(ctx, e.cache)
-		for _, fn := range e.cache.onHit {
-			fn(ctx, key, e.val, e.err)
+	if !miss && len(c.onHit) > 0 {
+		cbCtx := NewContext(ctx, c)
+		for _, fn := range c.onHit {
+			fn(cbCtx, key, e.val, e.err)
 		}
 	}
 
@@ -637,10 +652,10 @@ func getValueSlow[K comparable, V any](ctx context.Context, e *entry[K, V], key 
 // getValueFast is the Get core used when no Get-triggered callbacks are
 // registered, which is the common case. It skips the OnMiss/OnFill/OnHit
 // iteration entirely.
-func getValueFast[K comparable, V any](ctx context.Context, e *entry[K, V], key K) (V, error) {
+func getValueFast[K comparable, V any](c *Cache[K, V], ctx context.Context, e *entry[K, V], key K) (V, error) {
 	e.once.Do(func() {
-		ctx = NewContext(ctx, e.cache)
-		e.val, e.err = e.cache.fetch(ctx, key)
+		cbCtx := NewContext(ctx, c)
+		e.val, e.err = callFetch(c, cbCtx, key)
 		e.filled.Store(true)
 	})
 
@@ -690,25 +705,30 @@ func FromContext[K comparable, V any](ctx context.Context) *Cache[K, V] {
 	return nil
 }
 
-// randomName returns a default cache name of the form "cache-XXXXXXXX" where
-// X is a hex digit. The value is drawn from crypto/rand and hashed via
-// CRC-32 to produce a short, roughly-unique identifier suitable for logs.
-// It is not intended to be cryptographically secure — collisions across
-// many caches are acceptable since names are only used for display.
+// randomName returns a default cache name of the form "cache-XXXXXXXX"
+// where X is a hex digit. Random bytes are drawn from crypto/rand; the
+// value is used only for display in logs and debug output, and is not
+// meant to be cryptographically strong.
 func randomName() string {
-	b := make([]byte, 128)
-	_, _ = rand.Read(b)
-	return fmt.Sprintf("cache-%x", crc32.ChecksumIEEE(b))
+	var b [4]byte
+	_, _ = rand.Read(b[:])
+	return fmt.Sprintf("cache-%x", b)
 }
 
 // isNil reports whether x is nil, or whether x is a typed-nil reference
-// type (pointer, channel, func, interface, map, slice). The deferred
-// recover guards against reflect.Value.IsNil panicking on non-nilable
-// kinds (e.g. struct, int): for those kinds we want to return false, which
-// is the value already initialized in the named return after the panic.
+// type (pointer, channel, func, interface, map, or slice). Non-nilable
+// kinds (struct, int, bool, etc.) are never nil and return false.
 func isNil(x any) bool {
-	defer func() { recover() }() //nolint:errcheck
-	return x == nil || reflect.ValueOf(x).IsNil()
+	if x == nil {
+		return true
+	}
+	v := reflect.ValueOf(x)
+	switch v.Kind() {
+	case reflect.Pointer, reflect.Chan, reflect.Func,
+		reflect.Interface, reflect.Map, reflect.Slice:
+		return v.IsNil()
+	}
+	return false
 }
 
 // uniq returns a new slice containing the elements of a in their original

--- a/oncecache.go
+++ b/oncecache.go
@@ -40,10 +40,14 @@
 // runs fetch and subsequent callers block until the fetch completes, then all
 // receive the same result.
 //
-// Synchronous callbacks run on the goroutine that triggered the event. They
-// must not touch the same cache for the same key (that re-enters the entry's
-// [sync.Once] and deadlocks). For long-running callbacks, prefer [OnEvent]
-// with a buffered channel.
+// Synchronous callbacks run on the goroutine that triggered the event.
+// [OnFill], [OnMiss], and [OnHit] callbacks must not call [Cache.Get] or
+// [Cache.MaybeSet] for the same key on the same cache — that re-enters
+// the entry's [sync.Once] and deadlocks — but they may freely act on
+// other keys or other caches (the foundation of composite-cache
+// propagation). [OnEvict] has no such restriction: it runs after the
+// cache's internal lock is released and may call any method on any
+// cache. For long-running work, prefer [OnEvent] with a buffered channel.
 package oncecache
 
 import (

--- a/oncecache.go
+++ b/oncecache.go
@@ -117,7 +117,9 @@ var ErrPanic = errors.New("oncecache: panic in FetchFunc")
 // The returned [Cache] is safe for concurrent use by multiple goroutines.
 //
 // Passing a nil fetch is permitted but limits the cache to [Cache.MaybeSet]
-// population: any [Cache.Get] for an unpopulated key will panic.
+// population: any [Cache.Get] for an unpopulated key returns the zero
+// value with an error wrapping [ErrPanic] (the recovered nil-pointer
+// dereference).
 func New[K comparable, V any](fetch FetchFunc[K, V], opts ...Opt) *Cache[K, V] {
 	c := &Cache[K, V]{
 		entries: map[K]*entry[K, V]{},

--- a/oncecache.go
+++ b/oncecache.go
@@ -497,6 +497,7 @@ type gobEntry[K comparable, V any] struct {
 // encoded. The fetch func and callbacks are not encoded. Entries whose fill is
 // still in-flight are omitted from the encoded output.
 func (c *Cache[K, V]) GobEncode() ([]byte, error) {
+	registerFillPanicErrorOnGob()
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -544,6 +545,7 @@ func (c *Cache[K, V]) GobEncode() ([]byte, error) {
 // GobDecode does not fire [OnEvict] for the pre-existing entries it clears,
 // nor [OnFill] for the decoded entries it installs.
 func (c *Cache[K, V]) GobDecode(p []byte) error {
+	registerFillPanicErrorOnGob()
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -625,14 +627,19 @@ func (p *fillPanicError) GobDecode(data []byte) error {
 	return nil
 }
 
-// Pre-register fillPanicError with encoding/gob so panic-filled cache
-// entries survive GobEncode/GobDecode without requiring the caller to
-// register an unexported type they can't name. The var-func pattern is
-// used in place of init() to satisfy the gochecknoinits linter.
-var _ = func() struct{} {
-	gob.Register(&fillPanicError{})
-	return struct{}{}
-}()
+// gobRegisterFillPanic ensures fillPanicError is registered with
+// encoding/gob exactly once per process, so panic-filled cache entries
+// round-trip through GobEncode/GobDecode without requiring the caller to
+// register an unexported type they can't name.
+var gobRegisterFillPanic sync.Once
+
+// registerFillPanicErrorOnGob registers fillPanicError with gob on first
+// call. Called from [Cache.GobEncode] and [Cache.GobDecode].
+func registerFillPanicErrorOnGob() {
+	gobRegisterFillPanic.Do(func() {
+		gob.Register(&fillPanicError{})
+	})
+}
 
 // callFetch invokes c.fetch, recovering any panic and converting it into
 // an error wrapping [ErrPanic]. The recovered panic is NOT re-thrown:

--- a/oncecache.go
+++ b/oncecache.go
@@ -176,6 +176,11 @@ func (c *Cache[K, V]) applyOpts(opts []Opt) {
 		case Name:
 			s := string(o)
 			c.name.Store(&s)
+		case *Name:
+			// Name has a value receiver on its marker method, so *Name
+			// also satisfies Opt. Accept pointer-to-Name for forgiveness.
+			s := string(*o)
+			c.name.Store(&s)
 		case logOptConfig:
 			(*logOpt[K, V])(&o).apply(c)
 		case optApplier[K, V]:
@@ -523,12 +528,18 @@ func (c *Cache[K, V]) GobEncode() ([]byte, error) {
 //
 // Unlike other methods, GobDecode is safe to call on a zero-value [Cache]
 // (as gob-provided decoding into `var c Cache[K, V]` will do): it
-// initializes the internal map on demand. The decoded cache will have no
-// fetch func and no callbacks; set those via [New] if needed before
-// further use.
+// initializes the internal map and dispatch functions on demand. The
+// decoded cache will have no fetch func and no callbacks, so further
+// [Cache.Get] for a key not already in the decoded map yields an error
+// wrapping [ErrPanic] (the recovered nil-fetch call).
 //
 // The error type(s) used in entries with non-nil fill errors must be
-// registered with [gob.Register] before encoding/decoding.
+// registered with [gob.Register] before encoding/decoding. The package
+// pre-registers its internal panic-wrapper type, so panic-filled entries
+// also round-trip.
+//
+// Nil map values in a crafted or corrupted gob payload are skipped rather
+// than dereferenced; they do not cause a panic.
 //
 // GobDecode does not fire [OnEvict] for the pre-existing entries it clears,
 // nor [OnFill] for the decoded entries it installs.
@@ -548,7 +559,21 @@ func (c *Cache[K, V]) GobDecode(p []byte) error {
 	} else {
 		clear(c.entries)
 	}
+	// Initialize dispatch functions on demand so a zero-value Cache is
+	// usable for Get / MaybeSet after GobDecode. A decoded cache has no
+	// callbacks, so the fast variants are always correct here.
+	if c.getValueFn == nil {
+		c.getValueFn = getValueFast[K, V]
+	}
+	if c.maybeSetValueFn == nil {
+		c.maybeSetValueFn = maybeSetValueFast[K, V]
+	}
 	for k, e := range gbd.Entries {
+		if e == nil {
+			// A corrupt or crafted gob payload can contain nil map
+			// values. Skip rather than panic on dereference.
+			continue
+		}
 		ent := &entry[K, V]{val: e.Val, err: e.Err}
 		ent.once.Do(func() {}) // Consume the sync.Once
 		ent.filled.Store(true)
@@ -587,6 +612,27 @@ type fillPanicError struct {
 
 func (p *fillPanicError) Error() string { return fmt.Sprintf("%s: %s", ErrPanic, p.recovered) }
 func (p *fillPanicError) Unwrap() error { return ErrPanic }
+
+// GobEncode / GobDecode let fillPanicError round-trip cleanly even though
+// its only field is unexported — gob otherwise encodes no fields, losing
+// the recovered message.
+func (p *fillPanicError) GobEncode() ([]byte, error) {
+	return []byte(p.recovered), nil
+}
+
+func (p *fillPanicError) GobDecode(data []byte) error {
+	p.recovered = string(data)
+	return nil
+}
+
+// Pre-register fillPanicError with encoding/gob so panic-filled cache
+// entries survive GobEncode/GobDecode without requiring the caller to
+// register an unexported type they can't name. The var-func pattern is
+// used in place of init() to satisfy the gochecknoinits linter.
+var _ = func() struct{} {
+	gob.Register(&fillPanicError{})
+	return struct{}{}
+}()
 
 // callFetch invokes c.fetch, recovering any panic and converting it into
 // an error wrapping [ErrPanic]. The recovered panic is NOT re-thrown:

--- a/oncecache_internal_test.go
+++ b/oncecache_internal_test.go
@@ -1,0 +1,158 @@
+package oncecache
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestApplyOpts_UnknownPanics exercises the defensive panic in applyOpts
+// when an Opt is none of the recognized internal kinds. Because the [Opt]
+// interface is closed (the marker method is unexported), this branch is
+// unreachable from outside the package; we test it via an internal stub.
+func TestApplyOpts_UnknownPanics(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic from applyOpts on unknown Opt type")
+		}
+		if s, ok := r.(string); !ok || !strings.Contains(s, "Invalid Opt type") {
+			t.Fatalf("unexpected panic value: %v", r)
+		}
+	}()
+	c := New[int, int](func(_ context.Context, k int) (int, error) { return k, nil })
+	c.applyOpts([]Opt{badOpt{}})
+}
+
+// TestRandomName_Format verifies the documented "cache-XXXXXXXX" shape:
+// 8 lowercase hex digits.
+func TestRandomName_Format(t *testing.T) {
+	t.Parallel()
+	const prefix = "cache-"
+	for i := 0; i < 20; i++ {
+		name := randomName()
+		if !strings.HasPrefix(name, prefix) {
+			t.Fatalf("missing prefix: %q", name)
+		}
+		hex := name[len(prefix):]
+		if len(hex) != 8 {
+			t.Fatalf("expected 8 hex digits, got %d in %q", len(hex), name)
+		}
+		for _, r := range hex {
+			if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f')) {
+				t.Fatalf("non-hex character %q in %q", r, name)
+			}
+		}
+	}
+}
+
+// TestIsNil verifies the kind-aware nil check across nilable and
+// non-nilable kinds.
+func TestIsNil(t *testing.T) {
+	t.Parallel()
+
+	if !isNil(nil) {
+		t.Error("plain nil")
+	}
+
+	var p *int
+	if !isNil(p) {
+		t.Error("nil *int")
+	}
+	x := 0
+	if isNil(&p) || isNil(&x) {
+		t.Error("non-nil pointers")
+	}
+
+	var s []int
+	if !isNil(s) {
+		t.Error("nil []int")
+	}
+	if isNil([]int{}) {
+		t.Error("empty (non-nil) slice")
+	}
+
+	var m map[string]int
+	if !isNil(m) {
+		t.Error("nil map")
+	}
+	if isNil(map[string]int{}) {
+		t.Error("empty (non-nil) map")
+	}
+
+	var fn func()
+	if !isNil(fn) {
+		t.Error("nil func")
+	}
+	if isNil(func() {}) {
+		t.Error("non-nil func")
+	}
+
+	var ch chan int
+	if !isNil(ch) {
+		t.Error("nil chan")
+	}
+
+	// Non-nilable kinds: should always return false (and must not panic).
+	if isNil(0) {
+		t.Error("int 0 must not be nil")
+	}
+	if isNil(false) {
+		t.Error("bool false must not be nil")
+	}
+	if isNil("") {
+		t.Error("empty string must not be nil")
+	}
+	if isNil(struct{}{}) {
+		t.Error("empty struct must not be nil")
+	}
+	type s2 struct{ x int }
+	if isNil(s2{}) {
+		t.Error("zero-value struct must not be nil")
+	}
+}
+
+// TestUniq covers the small uniq helper across degenerate and typical
+// inputs.
+func TestUniq(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in, want []int
+	}{
+		{nil, []int{}},
+		{[]int{}, []int{}},
+		{[]int{1}, []int{1}},
+		{[]int{1, 1, 1}, []int{1}},
+		{[]int{1, 2, 3}, []int{1, 2, 3}},
+		{[]int{3, 1, 2, 1, 3}, []int{3, 1, 2}}, // first-occurrence order preserved
+	}
+	for _, tc := range cases {
+		got := uniq(tc.in)
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("uniq(%v) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestFillPanic_Error_Format verifies the format of the wrapped error
+// string and its Unwrap chain.
+func TestFillPanic_Error_Format(t *testing.T) {
+	t.Parallel()
+	p := &fillPanic{recovered: "boom"}
+	if !strings.HasSuffix(p.Error(), ": boom") {
+		t.Errorf("error format: %q", p.Error())
+	}
+	if p.Unwrap() != ErrPanic {
+		t.Errorf("Unwrap should yield ErrPanic, got %v", p.Unwrap())
+	}
+}
+
+// badOpt satisfies Opt (the marker method is unexported, but we can
+// implement it in this internal test package) without implementing any of
+// the recognized internal kinds. It exists solely to drive the panic
+// branch in applyOpts.
+type badOpt struct{}
+
+func (badOpt) optioner() {}

--- a/oncecache_internal_test.go
+++ b/oncecache_internal_test.go
@@ -41,7 +41,10 @@ func TestRandomName_Format(t *testing.T) {
 			t.Fatalf("expected 8 hex digits, got %d in %q", len(hex), name)
 		}
 		for _, r := range hex {
-			if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f')) {
+			switch {
+			case r >= '0' && r <= '9':
+			case r >= 'a' && r <= 'f':
+			default:
 				t.Fatalf("non-hex character %q in %q", r, name)
 			}
 		}
@@ -108,9 +111,9 @@ func TestIsNil(t *testing.T) {
 	if isNil(struct{}{}) {
 		t.Error("empty struct must not be nil")
 	}
-	type s2 struct{ x int }
-	if isNil(s2{}) {
-		t.Error("zero-value struct must not be nil")
+	type withField struct{ N int }
+	if isNil(withField{N: 42}) {
+		t.Error("non-empty struct must not be nil")
 	}
 }
 
@@ -140,10 +143,11 @@ func TestUniq(t *testing.T) {
 // string and its Unwrap chain.
 func TestFillPanic_Error_Format(t *testing.T) {
 	t.Parallel()
-	p := &fillPanic{recovered: "boom"}
+	p := &fillPanicError{recovered: "boom"}
 	if !strings.HasSuffix(p.Error(), ": boom") {
 		t.Errorf("error format: %q", p.Error())
 	}
+	//nolint:errorlint // directly checking the immediate Unwrap target, not chain.
 	if p.Unwrap() != ErrPanic {
 		t.Errorf("Unwrap should yield ErrPanic, got %v", p.Unwrap())
 	}

--- a/oncecache_test.go
+++ b/oncecache_test.go
@@ -758,7 +758,7 @@ func TestOnMiss(t *testing.T) {
 	var mu sync.Mutex
 	c := oncecache.New[int, int](
 		fetchDouble,
-		oncecache.OnMiss[int, int](func(_ context.Context, k int) {
+		oncecache.OnMiss(func(_ context.Context, k int, _ int, _ error) {
 			mu.Lock()
 			missKeys = append(missKeys, k)
 			mu.Unlock()
@@ -837,12 +837,11 @@ func TestClear_Empty(t *testing.T) {
 	require.Equal(t, 0, c.Len())
 }
 
-// TestFetchPanic documents the current behavior when the fetch function
-// panics. The panic propagates to the Get caller; [sync.Once] records the
-// call as done, so the entry is permanently cached as the zero value with
-// nil error and fetch is not reinvoked. OpMiss fires but OpFill does not —
-// which violates the "OpMiss is always immediately followed by OpFill" doc
-// invariant. See oncecache review item #3.
+// TestFetchPanic verifies that a panicking fetch is recovered into a
+// wrapped [oncecache.ErrPanic] error stored on the entry, that the
+// triggering Get returns that wrapped error rather than propagating the
+// panic, and that subsequent Gets return the same error without
+// reinvoking fetch. The OnMiss → OnFill lifecycle invariant is preserved.
 func TestFetchPanic(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -853,7 +852,7 @@ func TestFetchPanic(t *testing.T) {
 			fetchCalls.Add(1)
 			panic("boom")
 		},
-		oncecache.OnMiss[int, int](func(_ context.Context, _ int) {
+		oncecache.OnMiss(func(_ context.Context, _ int, _ int, _ error) {
 			missCalls.Add(1)
 		}),
 		oncecache.OnFill(func(_ context.Context, _, _ int, _ error) {
@@ -861,20 +860,19 @@ func TestFetchPanic(t *testing.T) {
 		}),
 	)
 
-	func() {
-		defer func() {
-			require.Equal(t, "boom", recover())
-		}()
-		_, _ = c.Get(ctx, 1)
-	}()
-	require.Equal(t, int64(1), fetchCalls.Load())
-	require.Equal(t, int64(1), missCalls.Load())
-	require.Equal(t, int64(0), fillCalls.Load()) // doc invariant violated
-
-	// Subsequent Get does not re-invoke fetch and returns (zero, nil).
 	v, err := c.Get(ctx, 1)
 	require.Zero(t, v)
-	require.NoError(t, err)
+	require.Error(t, err)
+	require.ErrorIs(t, err, oncecache.ErrPanic)
+	require.Contains(t, err.Error(), "boom")
+	require.Equal(t, int64(1), fetchCalls.Load())
+	require.Equal(t, int64(1), missCalls.Load())
+	require.Equal(t, int64(1), fillCalls.Load(), "OpFill must follow OpMiss even on panic")
+
+	// Subsequent Get returns the same wrapped error without reinvoking fetch.
+	v, err = c.Get(ctx, 1)
+	require.Zero(t, v)
+	require.ErrorIs(t, err, oncecache.ErrPanic)
 	require.Equal(t, int64(1), fetchCalls.Load())
 }
 
@@ -1044,6 +1042,172 @@ func TestOnEvent_Blocking(t *testing.T) {
 	_, _ = c.Get(ctx, 2)
 	_, _ = c.Get(ctx, 3)
 	require.Equal(t, 3, len(ch))
+}
+
+// TestOnEvent_BlockingCancellation verifies that a blocking OnEvent send
+// aborts when the triggering context is cancelled, so a stalled consumer
+// cannot hang the producer indefinitely.
+func TestOnEvent_BlockingCancellation(t *testing.T) {
+	t.Parallel()
+
+	ch := make(chan oncecache.Event[int, int]) // unbuffered, no receiver
+	c := oncecache.New[int, int](
+		fetchDouble,
+		oncecache.OnEvent(ch, true, oncecache.OpFill),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancelled
+	// Without ctx-cancellation in the OnEvent send path, this would hang.
+	done := make(chan struct{})
+	go func() {
+		_, _ = c.Get(ctx, 1)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Get hung; OnEvent blocking send did not honor ctx cancellation")
+	}
+}
+
+// TestEvent_Ctx verifies that delivered Events carry the triggering ctx,
+// and that FromContext on Event.Ctx yields the source cache.
+func TestEvent_Ctx(t *testing.T) {
+	t.Parallel()
+	type ctxKey struct{}
+	ctx := context.WithValue(context.Background(), ctxKey{}, "marker")
+
+	ch := make(chan oncecache.Event[int, int], 1)
+	c := oncecache.New[int, int](
+		fetchDouble,
+		oncecache.OnEvent(ch, false, oncecache.OpFill),
+	)
+
+	_, _ = c.Get(ctx, 1)
+
+	var ev oncecache.Event[int, int]
+	select {
+	case ev = <-ch:
+	case <-time.After(time.Second):
+		t.Fatal("no event received")
+	}
+	require.NotNil(t, ev.Ctx)
+	require.Equal(t, "marker", ev.Ctx.Value(ctxKey{}))
+	// Event.Ctx is decorated with the source cache.
+	require.Equal(t, c, oncecache.FromContext[int, int](ev.Ctx))
+}
+
+// TestConcurrentCloseAndGet verifies that Close races safely against Get.
+// With Close simplified to just clear entries (not detach callbacks), the
+// race detector should stay quiet.
+func TestConcurrentCloseAndGet(t *testing.T) {
+	t.Parallel()
+
+	const iters = 1000
+	c := oncecache.New[int, int](fetchDouble)
+	wg := &sync.WaitGroup{}
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			_, _ = c.Get(context.Background(), i)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters/10; i++ {
+			_ = c.Close()
+		}
+	}()
+	wg.Wait()
+}
+
+// TestGobDecode_Corrupted verifies that GobDecode returns an error for
+// malformed input and leaves the cache in a usable state.
+func TestGobDecode_Corrupted(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	c := oncecache.New[int, int](fetchDouble, oncecache.Name("orig"))
+
+	require.Error(t, c.GobDecode([]byte("not gob data at all")))
+	require.Error(t, c.GobDecode(nil))
+	require.Error(t, c.GobDecode([]byte{}))
+
+	// Cache survives the corrupt-decode attempts.
+	v, err := c.Get(ctx, 5)
+	require.NoError(t, err)
+	require.Equal(t, 10, v)
+	require.Equal(t, "orig", c.Name())
+}
+
+// TestCallback_RegistrationOrder verifies that when multiple callbacks of
+// the same op are registered, they fire in the order they were registered.
+func TestCallback_RegistrationOrder(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	var order []int
+	var mu sync.Mutex
+	mark := func(n int) func(context.Context, int, int, error) {
+		return func(_ context.Context, _, _ int, _ error) {
+			mu.Lock()
+			order = append(order, n)
+			mu.Unlock()
+		}
+	}
+	c := oncecache.New[int, int](
+		fetchDouble,
+		oncecache.OnFill(mark(1)),
+		oncecache.OnFill(mark(2)),
+		oncecache.OnFill(mark(3)),
+	)
+	_, _ = c.Get(ctx, 42)
+	require.Equal(t, []int{1, 2, 3}, order)
+}
+
+// TestDelete_Reentry verifies that an OnEvict callback may safely call
+// methods on the same cache (Get, Has, Len, Keys, even Delete on a
+// different key) without deadlocking. This is the snapshot-then-callback
+// guarantee added in the Delete/Clear concurrency fix.
+func TestDelete_Reentry(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	var c *oncecache.Cache[int, int]
+	c = oncecache.New[int, int](
+		fetchDouble,
+		oncecache.OnEvict(func(_ context.Context, k int, _ int, _ error) {
+			// Touch the cache from inside the eviction callback. With the
+			// pre-fix code that held c.mu across callbacks, all of these
+			// would deadlock.
+			_ = c.Has(k)
+			_ = c.Len()
+			_ = c.Keys()
+			if k == 1 {
+				c.Delete(ctx, 99) // a different (absent) key
+			}
+		}),
+	)
+	_, _ = c.Get(ctx, 1)
+	c.Delete(ctx, 1)
+}
+
+// TestClear_Reentry verifies that an OnEvict callback fired by Clear may
+// safely call methods on the same cache without deadlocking.
+func TestClear_Reentry(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	var c *oncecache.Cache[int, int]
+	c = oncecache.New[int, int](
+		fetchDouble,
+		oncecache.OnEvict(func(_ context.Context, _, _ int, _ error) {
+			_ = c.Has(0)
+			_ = c.Len()
+		}),
+	)
+	_, _ = c.Get(ctx, 1)
+	_, _ = c.Get(ctx, 2)
+	c.Clear(ctx)
 }
 
 // BenchmarkGet_Hit measures a single-goroutine steady-state cache hit.

--- a/oncecache_test.go
+++ b/oncecache_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math/rand"
 	"slices"
 	"strconv"
 	"sync"
@@ -1208,6 +1209,450 @@ func TestClear_Reentry(t *testing.T) {
 	_, _ = c.Get(ctx, 1)
 	_, _ = c.Get(ctx, 2)
 	c.Clear(ctx)
+}
+
+// TestErrPanic_IsTarget verifies that errors.Is(err, ErrPanic) matches the
+// wrapped error returned by Get after a fetch panic.
+func TestErrPanic_IsTarget(t *testing.T) {
+	t.Parallel()
+	c := oncecache.New[int, int](
+		func(_ context.Context, _ int) (int, error) {
+			panic(errors.New("boom-as-error"))
+		},
+	)
+	_, err := c.Get(context.Background(), 1)
+	require.Error(t, err)
+	require.ErrorIs(t, err, oncecache.ErrPanic)
+	require.Equal(t, oncecache.ErrPanic, errors.Unwrap(err))
+	require.Contains(t, err.Error(), "boom-as-error")
+}
+
+// TestFetchPanic_MaybeSetIsNoop verifies that after a panicked fetch
+// has filled the entry with a wrapped error, MaybeSet for that key is
+// a no-op (the entry is already considered filled).
+func TestFetchPanic_MaybeSetIsNoop(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	c := oncecache.New[int, string](
+		func(_ context.Context, _ int) (string, error) { panic("boom") },
+	)
+	_, _ = c.Get(ctx, 1) // panic recovered → entry filled with wrapped err
+	require.False(t, c.MaybeSet(ctx, 1, "override", nil))
+	_, err := c.Get(ctx, 1)
+	require.ErrorIs(t, err, oncecache.ErrPanic)
+}
+
+// TestGet_NilFetch verifies that constructing a cache with a nil fetch
+// and then calling Get on an unfilled key returns a wrapped ErrPanic
+// (the recovered nil-pointer dereference) rather than propagating the
+// panic. The cache is otherwise usable via MaybeSet.
+func TestGet_NilFetch(t *testing.T) {
+	t.Parallel()
+	c := oncecache.New[int, int](nil)
+
+	v, err := c.Get(context.Background(), 1)
+	require.Zero(t, v)
+	require.ErrorIs(t, err, oncecache.ErrPanic,
+		"nil fetch should be recovered into a wrapped ErrPanic, not propagated")
+
+	// MaybeSet works with nil fetch.
+	require.True(t, c.MaybeSet(context.Background(), 2, 22, nil))
+	v, err = c.Get(context.Background(), 2)
+	require.NoError(t, err)
+	require.Equal(t, 22, v)
+}
+
+// TestConcurrentMaybeSet verifies that, under heavy concurrent MaybeSet
+// for the same key, exactly one call wins (returns true) and all others
+// return false. The winner's value is what subsequent Get observes.
+func TestConcurrentMaybeSet(t *testing.T) {
+	t.Parallel()
+	const concurrency = 200
+	c := oncecache.New[int, int](fetchDouble)
+
+	var winners atomic.Int64
+	wg := &sync.WaitGroup{}
+	wg.Add(concurrency)
+	for i := 0; i < concurrency; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			if c.MaybeSet(context.Background(), 7, i, nil) {
+				winners.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+	require.Equal(t, int64(1), winners.Load(), "exactly one MaybeSet must win")
+
+	// Whatever value won is consistent across subsequent reads.
+	v1, _ := c.Get(context.Background(), 7)
+	v2, _ := c.Get(context.Background(), 7)
+	require.Equal(t, v1, v2)
+	require.GreaterOrEqual(t, v1, 0)
+	require.Less(t, v1, concurrency)
+}
+
+// TestMaybeSet_VsGetConcurrent verifies that under a race between Get
+// (which would invoke fetch) and MaybeSet (which would set directly),
+// exactly one populates the entry; both eventual reads agree.
+func TestMaybeSet_VsGetConcurrent(t *testing.T) {
+	t.Parallel()
+	const iters = 500
+	for i := 0; i < iters; i++ {
+		var fetchCalls atomic.Int64
+		c := oncecache.New[int, int](
+			func(_ context.Context, k int) (int, error) {
+				fetchCalls.Add(1)
+				return k * 2, nil
+			},
+		)
+		wg := &sync.WaitGroup{}
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			_ = c.MaybeSet(context.Background(), 1, 999, nil)
+		}()
+		go func() {
+			defer wg.Done()
+			_, _ = c.Get(context.Background(), 1)
+		}()
+		wg.Wait()
+
+		v, err := c.Get(context.Background(), 1)
+		require.NoError(t, err)
+		// The winner is either MaybeSet (v=999) or Get's fetch (v=2).
+		require.Contains(t, []int{2, 999}, v)
+		// Fetch ran at most once (zero if MaybeSet won the race).
+		require.LessOrEqual(t, fetchCalls.Load(), int64(1))
+	}
+}
+
+// TestOnHit_ErrorEntry verifies that OnHit fires when Get returns an
+// already-stored fill error (errorful entries are valid hits).
+func TestOnHit_ErrorEntry(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	wantErr := errors.New("nope")
+	var hits atomic.Int64
+	c := oncecache.New[int, string](
+		func(_ context.Context, _ int) (string, error) { return "", wantErr },
+		oncecache.OnHit(func(_ context.Context, _ int, val string, err error) {
+			require.Empty(t, val)
+			require.Equal(t, wantErr, err)
+			hits.Add(1)
+		}),
+	)
+	_, _ = c.Get(ctx, 1) // miss → fill (error)
+	_, err := c.Get(ctx, 1)
+	require.ErrorIs(t, err, wantErr)
+	require.Equal(t, int64(1), hits.Load())
+}
+
+// TestOnFill_PanicPropagates verifies that callback panics are NOT
+// recovered (only fetch panics are). The panic propagates to the Get
+// caller, but the entry is still filled, so subsequent Gets succeed.
+func TestOnFill_PanicPropagates(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	c := oncecache.New[int, int](
+		fetchDouble,
+		oncecache.OnFill(func(_ context.Context, _, _ int, _ error) { panic("cb-boom") }),
+	)
+	require.PanicsWithValue(t, "cb-boom", func() { _, _ = c.Get(ctx, 1) })
+	// The entry was filled before OnFill ran, so subsequent Gets succeed
+	// (and fire OnHit if registered, not OnFill again).
+	v, err := c.Get(ctx, 1)
+	require.NoError(t, err)
+	require.Equal(t, 2, v)
+}
+
+// TestOnEvict_PanicPropagates verifies that OnEvict panics propagate to
+// the Delete caller. The entry is removed before OnEvict runs.
+func TestOnEvict_PanicPropagates(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	c := oncecache.New[int, int](
+		fetchDouble,
+		oncecache.OnEvict(func(_ context.Context, _, _ int, _ error) { panic("evict-boom") }),
+	)
+	_, _ = c.Get(ctx, 1)
+	require.PanicsWithValue(t, "evict-boom", func() { c.Delete(ctx, 1) })
+	require.False(t, c.Has(1), "entry must be removed even though OnEvict panicked")
+}
+
+// TestLog_NilLevel verifies that passing a nil leveler to Log defaults
+// to slog.LevelInfo and produces output.
+func TestLog_NilLevel(t *testing.T) {
+	t.Parallel()
+	buf, log := newBufLogger()
+	c := oncecache.New[int, int](
+		fetchDouble,
+		oncecache.Name("nillevel"),
+		oncecache.Log(log, nil, oncecache.OpFill),
+	)
+	_, _ = c.Get(context.Background(), 1)
+	out := buf.String()
+	require.Contains(t, out, "level=INFO")
+	require.Contains(t, out, "ev.cache=nillevel")
+	require.Contains(t, out, "ev.op=fill")
+}
+
+// TestEntry_LogValue_Types verifies isValLogged behavior across V types:
+// numerics, bool, slog.LogValuer types are logged; string and arbitrary
+// structs are not.
+func TestEntry_LogValue_Types(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("int_logged", func(t *testing.T) {
+		buf, log := newBufLogger()
+		c := oncecache.New[int, int](
+			fetchDouble,
+			oncecache.Name("ints"),
+			oncecache.Log(log, slog.LevelInfo, oncecache.OpFill),
+		)
+		_, _ = c.Get(ctx, 5)
+		require.Contains(t, buf.String(), "ev.v=10")
+	})
+
+	t.Run("string_not_logged", func(t *testing.T) {
+		buf, log := newBufLogger()
+		c := oncecache.New[int, string](
+			func(_ context.Context, k int) (string, error) { return "secret", nil },
+			oncecache.Name("strs"),
+			oncecache.Log(log, slog.LevelInfo, oncecache.OpFill),
+		)
+		_, _ = c.Get(ctx, 1)
+		require.NotContains(t, buf.String(), "secret",
+			"string V must not appear in slog output")
+	})
+
+	t.Run("logvaluer_logged", func(t *testing.T) {
+		buf, log := newBufLogger()
+		c := oncecache.New[int, hasLogValue](
+			func(_ context.Context, k int) (hasLogValue, error) {
+				return hasLogValue{tag: "TAGGED"}, nil
+			},
+			oncecache.Name("lv"),
+			oncecache.Log(log, slog.LevelInfo, oncecache.OpFill),
+		)
+		_, _ = c.Get(ctx, 1)
+		require.Contains(t, buf.String(), "TAGGED")
+	})
+
+	t.Run("struct_not_logged", func(t *testing.T) {
+		buf, log := newBufLogger()
+		c := oncecache.New[int, plainStruct](
+			func(_ context.Context, k int) (plainStruct, error) {
+				return plainStruct{secret: "nope"}, nil
+			},
+			oncecache.Name("ps"),
+			oncecache.Log(log, slog.LevelInfo, oncecache.OpFill),
+		)
+		_, _ = c.Get(ctx, 1)
+		require.NotContains(t, buf.String(), "nope",
+			"plain struct V must not appear in slog output")
+	})
+}
+
+// hasLogValue is a V type implementing slog.LogValuer.
+type hasLogValue struct {
+	tag string
+}
+
+func (h hasLogValue) LogValue() slog.Value { return slog.StringValue(h.tag) }
+
+// plainStruct is a V type that does NOT implement slog.LogValuer.
+type plainStruct struct {
+	secret string
+}
+
+// TestEntry_String verifies the compact debug format with and without err.
+func TestEntry_String(t *testing.T) {
+	t.Parallel()
+	c := oncecache.New[int, int](fetchDouble, oncecache.Name("nm"))
+
+	ev := oncecache.Entry[int, int]{Cache: c, Key: 7, Val: 14}
+	require.Equal(t, "nm[7]", ev.String())
+
+	ev.Err = errors.New("oof")
+	require.Equal(t, "nm[7][! oof]", ev.String())
+}
+
+// TestEvent_String verifies the compact debug format for events.
+func TestEvent_String(t *testing.T) {
+	t.Parallel()
+	c := oncecache.New[int, int](fetchDouble, oncecache.Name("nm"))
+
+	e := oncecache.Event[int, int]{
+		Op:    oncecache.OpHit,
+		Entry: oncecache.Entry[int, int]{Cache: c, Key: 7, Val: 14},
+	}
+	require.Equal(t, "nm.hit[7]", e.String())
+
+	e.Err = errors.New("oof")
+	require.Equal(t, "nm.hit[7][! oof]", e.String())
+}
+
+// TestOp_IsZero_All verifies that all defined Op constants are non-zero
+// and only the zero-value Op reports IsZero.
+func TestOp_IsZero_All(t *testing.T) {
+	t.Parallel()
+	for _, op := range []oncecache.Op{oncecache.OpHit, oncecache.OpMiss, oncecache.OpFill, oncecache.OpEvict} {
+		require.False(t, op.IsZero(), "%s must not be zero", op)
+	}
+	require.True(t, oncecache.Op(0).IsZero())
+}
+
+// TestNewContext_PreservesParent verifies that NewContext does not destroy
+// pre-existing values on the parent context.
+func TestNewContext_PreservesParent(t *testing.T) {
+	t.Parallel()
+	type k struct{}
+	parent := context.WithValue(context.Background(), k{}, "parent-value")
+	c := oncecache.New[int, int](fetchDouble)
+	ctx := oncecache.NewContext(parent, c)
+	require.Equal(t, "parent-value", ctx.Value(k{}))
+	require.Equal(t, c, oncecache.FromContext[int, int](ctx))
+}
+
+// TestFromContext_NestedCachesInnerWins verifies that when ctx has been
+// decorated with two caches of the same K/V type, the most-recently-stored
+// (innermost) cache is returned.
+func TestFromContext_NestedCachesInnerWins(t *testing.T) {
+	t.Parallel()
+	c1 := oncecache.New[int, int](fetchDouble, oncecache.Name("outer"))
+	c2 := oncecache.New[int, int](fetchDouble, oncecache.Name("inner"))
+	ctx := oncecache.NewContext(oncecache.NewContext(context.Background(), c1), c2)
+	got := oncecache.FromContext[int, int](ctx)
+	require.Equal(t, "inner", got.Name())
+}
+
+// TestCache_AsSlogAttribute verifies that a Cache can be passed directly
+// to slog and produces a useful structured representation.
+func TestCache_AsSlogAttribute(t *testing.T) {
+	t.Parallel()
+	buf, log := newBufLogger()
+	c := oncecache.New[int, string](
+		func(_ context.Context, k int) (string, error) { return "v", nil },
+		oncecache.Name("attr-cache"),
+	)
+	_, _ = c.Get(context.Background(), 1)
+	_, _ = c.Get(context.Background(), 2)
+	log.Info("status", "cache", c)
+	out := buf.String()
+	require.Contains(t, out, "attr-cache")
+	require.Contains(t, out, "entries=2")
+	require.Contains(t, out, "key=int")
+	require.Contains(t, out, "val=string")
+}
+
+// TestStress runs random concurrent Get/MaybeSet/Delete/Clear/Has/Keys
+// operations against the cache for a fixed duration. Its job is to
+// surface races, deadlocks, and panics that targeted tests may miss.
+// Run with -race to be useful.
+func TestStress(t *testing.T) {
+	t.Parallel()
+	const goroutines = 32
+	const opsPerGoroutine = 2000
+	const keyspace = 64
+
+	var fetchCalls atomic.Int64
+	c := oncecache.New[int, int](
+		func(_ context.Context, k int) (int, error) {
+			fetchCalls.Add(1)
+			return k * 2, nil
+		},
+		oncecache.OnFill(func(_ context.Context, _, _ int, _ error) {}),
+		oncecache.OnEvict(func(_ context.Context, _, _ int, _ error) {}),
+		oncecache.OnHit(func(_ context.Context, _, _ int, _ error) {}),
+	)
+
+	wg := &sync.WaitGroup{}
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		g := g
+		go func() {
+			defer wg.Done()
+			rng := rand.New(rand.NewSource(int64(g)))
+			ctx := context.Background()
+			for i := 0; i < opsPerGoroutine; i++ {
+				key := rng.Intn(keyspace)
+				switch rng.Intn(6) {
+				case 0:
+					_, _ = c.Get(ctx, key)
+				case 1:
+					_ = c.MaybeSet(ctx, key, key*10, nil)
+				case 2:
+					c.Delete(ctx, key)
+				case 3:
+					if rng.Intn(50) == 0 {
+						c.Clear(ctx)
+					}
+				case 4:
+					_ = c.Has(key)
+				case 5:
+					_ = c.Keys()
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	t.Logf("fetch invocations: %d (over %d ops, keyspace %d)",
+		fetchCalls.Load(), goroutines*opsPerGoroutine, keyspace)
+}
+
+// TestOnEvent_AllOpsDefault verifies that an empty ops list defaults to
+// delivering all four op kinds, and exercises the OpHit / OpMiss / OpEvict
+// branches of eventOpt.apply.
+func TestOnEvent_AllOpsDefault(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ch := make(chan oncecache.Event[int, int], 16)
+	c := oncecache.New[int, int](
+		fetchDouble,
+		oncecache.OnEvent(ch, false), // no ops → all four
+	)
+
+	_, _ = c.Get(ctx, 1) // miss + fill
+	_, _ = c.Get(ctx, 1) // hit
+	c.Delete(ctx, 1)     // evict
+
+	got := make(map[oncecache.Op]int)
+loop:
+	for {
+		select {
+		case ev := <-ch:
+			got[ev.Op]++
+		case <-time.After(50 * time.Millisecond):
+			break loop
+		}
+	}
+	require.Equal(t, 1, got[oncecache.OpMiss])
+	require.Equal(t, 1, got[oncecache.OpFill])
+	require.Equal(t, 1, got[oncecache.OpHit])
+	require.Equal(t, 1, got[oncecache.OpEvict])
+}
+
+// TestLog_DefaultOps verifies that calling Log with an empty ops list
+// logs all four op kinds.
+func TestLog_DefaultOps(t *testing.T) {
+	t.Parallel()
+	buf, log := newBufLogger()
+	c := oncecache.New[int, int](
+		fetchDouble,
+		oncecache.Name("dops"),
+		oncecache.Log(log, slog.LevelInfo), // no ops → all
+	)
+	_, _ = c.Get(context.Background(), 1) // miss + fill
+	_, _ = c.Get(context.Background(), 1) // hit
+	c.Delete(context.Background(), 1)     // evict
+
+	out := buf.String()
+	for _, op := range []string{"miss", "fill", "hit", "evict"} {
+		require.Contains(t, out, "ev.op="+op, "missing op=%s in output", op)
+	}
 }
 
 // BenchmarkGet_Hit measures a single-goroutine steady-state cache hit.

--- a/oncecache_test.go
+++ b/oncecache_test.go
@@ -1627,9 +1627,10 @@ func TestStress(t *testing.T) {
 	wg := &sync.WaitGroup{}
 	wg.Add(goroutines)
 	for g := 0; g < goroutines; g++ {
+		seed := int64(g)
 		go func() {
 			defer wg.Done()
-			rng := rand.New(rand.NewSource(int64(g)))
+			rng := rand.New(rand.NewSource(seed))
 			ctx := context.Background()
 			for i := 0; i < opsPerGoroutine; i++ {
 				key := rng.Intn(keyspace)

--- a/oncecache_test.go
+++ b/oncecache_test.go
@@ -1713,6 +1713,78 @@ func TestLog_DefaultOps(t *testing.T) {
 	}
 }
 
+// TestGobDecode_ZeroCache verifies that decoding into a literal
+// `var c Cache[K, V]` produces a usable cache: Get on decoded keys
+// returns the decoded values, MaybeSet works, and Get on a new key
+// (no fetch func) yields a wrapped ErrPanic instead of panicking.
+func TestGobDecode_ZeroCache(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	c1 := oncecache.New[int, int](fetchDouble, oncecache.Name("zero-src"))
+	_, _ = c1.Get(ctx, 5)
+	_, _ = c1.Get(ctx, 6)
+	data, err := c1.GobEncode()
+	require.NoError(t, err)
+
+	// Decode into a literal zero-value cache.
+	var c2 oncecache.Cache[int, int]
+	require.NoError(t, c2.GobDecode(data))
+	require.Equal(t, "zero-src", c2.Name())
+	require.Equal(t, 2, c2.Len())
+
+	// Get on decoded keys works and returns decoded values.
+	v, err := c2.Get(ctx, 5)
+	require.NoError(t, err)
+	require.Equal(t, 10, v)
+
+	// MaybeSet on a new key works.
+	require.True(t, c2.MaybeSet(ctx, 99, 999, nil))
+	v, err = c2.Get(ctx, 99)
+	require.NoError(t, err)
+	require.Equal(t, 999, v)
+
+	// Get on a key with no decoded entry and nil fetch returns a wrapped
+	// ErrPanic (the recovered nil-pointer dereference).
+	_, err = c2.Get(ctx, 777)
+	require.ErrorIs(t, err, oncecache.ErrPanic)
+}
+
+// TestGob_PanicFilledEntry verifies that entries whose fill error wraps
+// [oncecache.ErrPanic] round-trip cleanly through GobEncode/GobDecode —
+// the wrapped-error relationship is preserved on the decoded side.
+func TestGob_PanicFilledEntry(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	c1 := oncecache.New[int, int](
+		func(_ context.Context, _ int) (int, error) { panic("gob-me") },
+	)
+	_, err := c1.Get(ctx, 1) // recovers into wrapped ErrPanic
+	require.ErrorIs(t, err, oncecache.ErrPanic)
+
+	data, err := c1.GobEncode()
+	require.NoError(t, err, "gob must support panic-filled entries")
+
+	c2 := oncecache.New[int, int](fetchDouble)
+	require.NoError(t, c2.GobDecode(data))
+	v, err := c2.Get(ctx, 1)
+	require.Zero(t, v)
+	require.ErrorIs(t, err, oncecache.ErrPanic,
+		"decoded cache must preserve the ErrPanic relationship")
+	require.Contains(t, err.Error(), "gob-me",
+		"decoded cache must preserve the panic message")
+}
+
+// TestNew_PtrToName verifies that passing *Name (rather than Name) works
+// — a pointer to the typed alias is accepted rather than panicking.
+func TestNew_PtrToName(t *testing.T) {
+	t.Parallel()
+	n := oncecache.Name("ptr-cache")
+	c := oncecache.New[int, int](fetchDouble, &n)
+	require.Equal(t, "ptr-cache", c.Name())
+}
+
 // BenchmarkGet_Hit measures a single-goroutine steady-state cache hit.
 func BenchmarkGet_Hit(b *testing.B) {
 	ctx := context.Background()

--- a/oncecache_test.go
+++ b/oncecache_test.go
@@ -1935,11 +1935,12 @@ func ExampleCache_Keys() {
 	didSet = c.MaybeSet(ctx, 7, 13, nil) // Cache write: 7 not in cache
 	fmt.Println("Did set 7?", didSet)
 
-	c.Clear(ctx) // Clear empties c, but it's still usable
+	c.Clear(ctx) // Clear empties c, firing any OnEvict callbacks.
 	fmt.Println("Keys after cache clear:", c.Keys())
 
-	// Close clears c and releases resources. Afterwards, c is unusable,
-	// and operations on it may return an error.
+	// Close empties the cache without firing OnEvict. Callbacks are
+	// retained and the cache remains fully usable for later Get /
+	// MaybeSet / Delete calls.
 	_ = c.Close()
 
 	// Output:

--- a/oncecache_test.go
+++ b/oncecache_test.go
@@ -3,6 +3,7 @@ package oncecache_test
 import (
 	"bytes"
 	"context"
+	"encoding/gob"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -135,6 +136,99 @@ func TestCacheConcurrent(t *testing.T) {
 	for i := 0; i < numbers; i++ {
 		assert.Equal(t, int64(1), invocations[i].Load(), "key %d", i)
 	}
+}
+
+// TestConcurrentDeleteAndFetch exercises the race between Delete/Clear and an
+// in-flight fetch populating the same entry. Before the filled-flag fix,
+// Delete/Clear would read e.val/e.err concurrently with the fetch goroutine's
+// write, which the race detector flagged. Running this under `-race` is the
+// regression check.
+func TestConcurrentDeleteAndFetch(t *testing.T) {
+	t.Parallel()
+
+	const iters = 2000
+	ctx := context.Background()
+
+	// Fetch does a bit of work to widen the race window.
+	fetch := func(_ context.Context, k int) (string, error) {
+		s := ""
+		for i := 0; i < 100; i++ {
+			s += "x"
+		}
+		return s, nil
+	}
+
+	var evictCalls atomic.Int64
+	c := oncecache.New[int, string](
+		fetch,
+		oncecache.OnEvict(func(_ context.Context, _ int, val string, err error) {
+			evictCalls.Add(1)
+			// If filled-flag check works, val is always the fetched value for
+			// evicted-after-fill entries, never a zero/torn read.
+			if val != "" && val != "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" {
+				t.Errorf("torn read on evict: val=%q", val)
+			}
+			if err != nil {
+				t.Errorf("unexpected err on evict: %v", err)
+			}
+		}),
+	)
+
+	wg := &sync.WaitGroup{}
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			_, _ = c.Get(ctx, i)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			c.Delete(ctx, i)
+		}
+	}()
+	wg.Wait()
+
+	// We don't assert an exact evict count: how many Deletes observe a filled
+	// entry vs. an in-flight one is timing-dependent. We only require that
+	// no data race fired and no torn reads happened (asserted above).
+	t.Logf("evict callbacks fired: %d/%d", evictCalls.Load(), iters)
+}
+
+// TestClearDuringFetch exercises Clear racing with in-flight fills.
+func TestClearDuringFetch(t *testing.T) {
+	t.Parallel()
+
+	const iters = 500
+	ctx := context.Background()
+
+	fetch := func(_ context.Context, k int) (int, error) { return k, nil }
+
+	c := oncecache.New[int, int](
+		fetch,
+		oncecache.OnEvict(func(_ context.Context, k int, val int, _ error) {
+			if val != k {
+				t.Errorf("torn read on evict: key=%d val=%d", k, val)
+			}
+		}),
+	)
+
+	wg := &sync.WaitGroup{}
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			_, _ = c.Get(ctx, i)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters/10; i++ {
+			c.Clear(ctx)
+		}
+	}()
+	wg.Wait()
 }
 
 // TestContext verifies that the context passed to callbacks is decorated with
@@ -583,6 +677,413 @@ func newBufLogger() (*bytes.Buffer, *slog.Logger) {
 		},
 	})
 	return buf, slog.New(h)
+}
+
+// TestClose exercises [Cache.Close] behaviors.
+func TestClose(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil_cache", func(t *testing.T) {
+		var c *oncecache.Cache[int, int]
+		require.NoError(t, c.Close())
+	})
+
+	t.Run("idempotent", func(t *testing.T) {
+		c := oncecache.New[int, int](fetchDouble)
+		require.NoError(t, c.Close())
+		require.NoError(t, c.Close())
+	})
+
+	t.Run("clears_entries", func(t *testing.T) {
+		ctx := context.Background()
+		c := oncecache.New[int, int](fetchDouble)
+		_, _ = c.Get(ctx, 1)
+		_, _ = c.Get(ctx, 2)
+		require.Equal(t, 2, c.Len())
+		require.NoError(t, c.Close())
+		require.Equal(t, 0, c.Len())
+	})
+
+	t.Run("detaches_callbacks", func(t *testing.T) {
+		ctx := context.Background()
+		var evicts atomic.Int64
+		c := oncecache.New[int, int](
+			fetchDouble,
+			oncecache.OnEvict(func(_ context.Context, _, _ int, _ error) {
+				evicts.Add(1)
+			}),
+		)
+		_, _ = c.Get(ctx, 1)
+		require.NoError(t, c.Close())
+		// OnEvict is not invoked by Close.
+		require.Equal(t, int64(0), evicts.Load())
+		// And after Close, Delete also doesn't fire OnEvict (callbacks detached).
+		c.Delete(ctx, 1)
+		require.Equal(t, int64(0), evicts.Load())
+	})
+}
+
+// TestOnHit verifies the [OnHit] callback fires on cache hits and not misses.
+func TestOnHit(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	var hits atomic.Int64
+	c := oncecache.New[int, int](
+		fetchDouble,
+		oncecache.OnHit(func(_ context.Context, k, v int, err error) {
+			require.NoError(t, err)
+			require.Equal(t, k*2, v)
+			hits.Add(1)
+		}),
+	)
+
+	_, _ = c.Get(ctx, 7) // miss → fill; no hit
+	require.Equal(t, int64(0), hits.Load())
+	_, _ = c.Get(ctx, 7) // hit
+	require.Equal(t, int64(1), hits.Load())
+	_, _ = c.Get(ctx, 7) // hit
+	require.Equal(t, int64(2), hits.Load())
+	_, _ = c.Get(ctx, 8) // miss → fill; no hit
+	require.Equal(t, int64(2), hits.Load())
+}
+
+// TestOnMiss verifies the [OnMiss] callback fires on cache misses only.
+func TestOnMiss(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	var misses atomic.Int64
+	var missKeys []int
+	var mu sync.Mutex
+	c := oncecache.New[int, int](
+		fetchDouble,
+		oncecache.OnMiss[int, int](func(_ context.Context, k int) {
+			mu.Lock()
+			missKeys = append(missKeys, k)
+			mu.Unlock()
+			misses.Add(1)
+		}),
+	)
+
+	_, _ = c.Get(ctx, 7) // miss
+	_, _ = c.Get(ctx, 7) // hit, no miss
+	_, _ = c.Get(ctx, 8) // miss
+	require.Equal(t, int64(2), misses.Load())
+	require.Equal(t, []int{7, 8}, missKeys)
+
+	// MaybeSet does not emit OpMiss.
+	require.True(t, c.MaybeSet(ctx, 9, 99, nil))
+	require.Equal(t, int64(2), misses.Load())
+	_, _ = c.Get(ctx, 9) // hit (already set), no miss
+	require.Equal(t, int64(2), misses.Load())
+}
+
+// TestMaybeSet_Error verifies that an entry set via MaybeSet with a non-nil
+// error preserves that error on subsequent Get calls.
+func TestMaybeSet_Error(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	c := oncecache.New[int, string](fetchEvenOnly)
+
+	wantErr := errors.New("boom")
+	require.True(t, c.MaybeSet(ctx, 42, "x", wantErr))
+	v, err := c.Get(ctx, 42)
+	require.Equal(t, "x", v)
+	require.Equal(t, wantErr, err)
+
+	// Errorful entries are still "filled" — MaybeSet is a no-op.
+	require.False(t, c.MaybeSet(ctx, 42, "y", nil))
+	v, err = c.Get(ctx, 42)
+	require.Equal(t, "x", v)
+	require.Equal(t, wantErr, err)
+}
+
+// TestDelete_NonExistent verifies Delete is a no-op when the key is absent,
+// and that OnEvict is not invoked.
+func TestDelete_NonExistent(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	var evicts atomic.Int64
+	c := oncecache.New[int, int](
+		fetchDouble,
+		oncecache.OnEvict(func(_ context.Context, _, _ int, _ error) {
+			evicts.Add(1)
+		}),
+	)
+
+	c.Delete(ctx, 42) // key was never set
+	require.Equal(t, int64(0), evicts.Load())
+	require.Equal(t, 0, c.Len())
+}
+
+// TestClear_Empty verifies Clear on an empty cache is a no-op.
+func TestClear_Empty(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	var evicts atomic.Int64
+	c := oncecache.New[int, int](
+		fetchDouble,
+		oncecache.OnEvict(func(_ context.Context, _, _ int, _ error) {
+			evicts.Add(1)
+		}),
+	)
+
+	c.Clear(ctx)
+	require.Equal(t, int64(0), evicts.Load())
+	require.Equal(t, 0, c.Len())
+}
+
+// TestFetchPanic documents the current behavior when the fetch function
+// panics. The panic propagates to the Get caller; [sync.Once] records the
+// call as done, so the entry is permanently cached as the zero value with
+// nil error and fetch is not reinvoked. OpMiss fires but OpFill does not —
+// which violates the "OpMiss is always immediately followed by OpFill" doc
+// invariant. See oncecache review item #3.
+func TestFetchPanic(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	var fetchCalls, missCalls, fillCalls atomic.Int64
+	c := oncecache.New[int, int](
+		func(_ context.Context, _ int) (int, error) {
+			fetchCalls.Add(1)
+			panic("boom")
+		},
+		oncecache.OnMiss[int, int](func(_ context.Context, _ int) {
+			missCalls.Add(1)
+		}),
+		oncecache.OnFill(func(_ context.Context, _, _ int, _ error) {
+			fillCalls.Add(1)
+		}),
+	)
+
+	func() {
+		defer func() {
+			require.Equal(t, "boom", recover())
+		}()
+		_, _ = c.Get(ctx, 1)
+	}()
+	require.Equal(t, int64(1), fetchCalls.Load())
+	require.Equal(t, int64(1), missCalls.Load())
+	require.Equal(t, int64(0), fillCalls.Load()) // doc invariant violated
+
+	// Subsequent Get does not re-invoke fetch and returns (zero, nil).
+	v, err := c.Get(ctx, 1)
+	require.Zero(t, v)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), fetchCalls.Load())
+}
+
+// TestGob_Empty verifies gob round-trip of an empty cache preserves the name.
+func TestGob_Empty(t *testing.T) {
+	t.Parallel()
+	c1 := oncecache.New[int, int](fetchDouble, oncecache.Name("empty"))
+
+	data, err := c1.GobEncode()
+	require.NoError(t, err)
+
+	c2 := oncecache.New[int, int](fetchDouble)
+	require.NoError(t, c2.GobDecode(data))
+	require.Equal(t, 0, c2.Len())
+	require.Equal(t, "empty", c2.Name())
+}
+
+// gobErr is a gob-registerable error type used by [TestGob_PreservesError].
+type gobErr string
+
+func (e gobErr) Error() string { return string(e) }
+
+func init() { gob.Register(gobErr("")) }
+
+// TestGob_PreservesError verifies that fill errors survive gob round-trip.
+func TestGob_PreservesError(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	myErr := gobErr("boom")
+	c1 := oncecache.New[int, int](
+		func(_ context.Context, k int) (int, error) {
+			if k == 0 {
+				return 0, myErr
+			}
+			return k * 2, nil
+		},
+	)
+	_, err := c1.Get(ctx, 0)
+	require.EqualError(t, err, "boom")
+	_, _ = c1.Get(ctx, 5)
+
+	data, err := c1.GobEncode()
+	require.NoError(t, err)
+
+	c2 := oncecache.New[int, int](
+		func(_ context.Context, _ int) (int, error) {
+			t.Fatal("fetch must not be invoked after GobDecode")
+			return 0, nil
+		},
+	)
+	require.NoError(t, c2.GobDecode(data))
+	require.Equal(t, 2, c2.Len())
+
+	v, err := c2.Get(ctx, 0)
+	require.Zero(t, v)
+	require.EqualError(t, err, "boom")
+
+	v, err = c2.Get(ctx, 5)
+	require.NoError(t, err)
+	require.Equal(t, 10, v)
+}
+
+// TestFromContext_NilOrWrongType verifies FromContext returns nil for nil
+// contexts, unset keys, and mismatched generic types.
+func TestFromContext_NilOrWrongType(t *testing.T) {
+	t.Parallel()
+
+	//nolint:staticcheck // intentionally passing nil ctx
+	require.Nil(t, oncecache.FromContext[int, int](nil))
+	require.Nil(t, oncecache.FromContext[int, int](context.Background()))
+
+	c1 := oncecache.New[string, string](func(_ context.Context, k string) (string, error) {
+		return k, nil
+	})
+	ctx := oncecache.NewContext(context.Background(), c1)
+	// Matching types: retrieval succeeds.
+	require.Equal(t, c1, oncecache.FromContext[string, string](ctx))
+	// Mismatched types: returns nil rather than panicking.
+	require.Nil(t, oncecache.FromContext[int, int](ctx))
+}
+
+// TestNewContext_NilCtx verifies NewContext with a nil context produces a
+// usable context backed by [context.Background].
+func TestNewContext_NilCtx(t *testing.T) {
+	t.Parallel()
+	c := oncecache.New[int, int](fetchDouble)
+	//nolint:staticcheck // intentionally passing nil ctx
+	ctx := oncecache.NewContext[int, int](nil, c)
+	require.NotNil(t, ctx)
+	require.Equal(t, c, oncecache.FromContext[int, int](ctx))
+}
+
+// TestNew_NilOpts verifies that nil [Opt] values passed to [New] are ignored.
+func TestNew_NilOpts(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	c := oncecache.New[int, int](
+		fetchDouble,
+		nil,
+		oncecache.Name("with-nils"),
+		nil,
+	)
+	require.Equal(t, "with-nils", c.Name())
+	v, _ := c.Get(ctx, 5)
+	require.Equal(t, 10, v)
+}
+
+// TestLog_NilLogger verifies Log with a nil logger returns a nil Opt that
+// does not register callbacks.
+func TestLog_NilLogger(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	c := oncecache.New[int, int](
+		fetchDouble,
+		oncecache.Log(nil, slog.LevelInfo),
+	)
+	v, err := c.Get(ctx, 3)
+	require.NoError(t, err)
+	require.Equal(t, 6, v)
+}
+
+// TestOp_String covers [Op.String] for valid ops and the "unknown" fallback,
+// and [Op.IsZero] for the zero value.
+func TestOp_String(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "hit", oncecache.OpHit.String())
+	require.Equal(t, "miss", oncecache.OpMiss.String())
+	require.Equal(t, "fill", oncecache.OpFill.String())
+	require.Equal(t, "evict", oncecache.OpEvict.String())
+	require.Equal(t, "unknown", oncecache.Op(0).String())
+	require.Equal(t, "unknown", oncecache.Op(99).String())
+	require.True(t, oncecache.Op(0).IsZero())
+	require.False(t, oncecache.OpHit.IsZero())
+}
+
+// TestOnEvent_NonBlocking_DropsOnFull verifies that non-blocking OnEvent
+// drops events when the receiver cannot keep up.
+func TestOnEvent_NonBlocking_DropsOnFull(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	ch := make(chan oncecache.Event[int, int], 1)
+	c := oncecache.New[int, int](
+		fetchDouble,
+		oncecache.OnEvent(ch, false, oncecache.OpFill),
+	)
+
+	_, _ = c.Get(ctx, 1)
+	_, _ = c.Get(ctx, 2)
+	_, _ = c.Get(ctx, 3)
+	require.Equal(t, 1, len(ch), "non-blocking OnEvent must drop events when full")
+}
+
+// TestOnEvent_Blocking verifies that blocking OnEvent delivers every event.
+func TestOnEvent_Blocking(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	ch := make(chan oncecache.Event[int, int], 3)
+	c := oncecache.New[int, int](
+		fetchDouble,
+		oncecache.OnEvent(ch, true, oncecache.OpFill),
+	)
+
+	_, _ = c.Get(ctx, 1)
+	_, _ = c.Get(ctx, 2)
+	_, _ = c.Get(ctx, 3)
+	require.Equal(t, 3, len(ch))
+}
+
+// BenchmarkGet_Hit measures a single-goroutine steady-state cache hit.
+func BenchmarkGet_Hit(b *testing.B) {
+	ctx := context.Background()
+	c := oncecache.New[int, int](fetchDouble)
+	_, _ = c.Get(ctx, 42)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = c.Get(ctx, 42)
+	}
+}
+
+// BenchmarkGet_Miss measures cache miss + fill for unique keys.
+func BenchmarkGet_Miss(b *testing.B) {
+	ctx := context.Background()
+	c := oncecache.New[int, int](fetchDouble)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = c.Get(ctx, i)
+	}
+}
+
+// BenchmarkGet_Parallel_Hit measures concurrent hits on a hot key.
+func BenchmarkGet_Parallel_Hit(b *testing.B) {
+	ctx := context.Background()
+	c := oncecache.New[int, int](fetchDouble)
+	_, _ = c.Get(ctx, 42)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_, _ = c.Get(ctx, 42)
+		}
+	})
 }
 
 //nolint:revive

--- a/oncecache_test.go
+++ b/oncecache_test.go
@@ -151,7 +151,9 @@ func TestConcurrentDeleteAndFetch(t *testing.T) {
 	ctx := context.Background()
 
 	// Fetch does a bit of work to widen the race window.
-	fetch := func(_ context.Context, k int) (string, error) {
+	const fetchedStr = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" +
+		"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+	fetch := func(_ context.Context, _ int) (string, error) {
 		s := ""
 		for i := 0; i < 100; i++ {
 			s += "x"
@@ -166,7 +168,7 @@ func TestConcurrentDeleteAndFetch(t *testing.T) {
 			evictCalls.Add(1)
 			// If filled-flag check works, val is always the fetched value for
 			// evicted-after-fill entries, never a zero/torn read.
-			if val != "" && val != "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" {
+			if val != "" && val != fetchedStr {
 				t.Errorf("torn read on evict: val=%q", val)
 			}
 			if err != nil {
@@ -208,7 +210,7 @@ func TestClearDuringFetch(t *testing.T) {
 
 	c := oncecache.New[int, int](
 		fetch,
-		oncecache.OnEvict(func(_ context.Context, k int, val int, _ error) {
+		oncecache.OnEvict(func(_ context.Context, k, val int, _ error) {
 			if val != k {
 				t.Errorf("torn read on evict: key=%d val=%d", k, val)
 			}
@@ -685,17 +687,20 @@ func TestClose(t *testing.T) {
 	t.Parallel()
 
 	t.Run("nil_cache", func(t *testing.T) {
+		t.Parallel()
 		var c *oncecache.Cache[int, int]
 		require.NoError(t, c.Close())
 	})
 
 	t.Run("idempotent", func(t *testing.T) {
+		t.Parallel()
 		c := oncecache.New[int, int](fetchDouble)
 		require.NoError(t, c.Close())
 		require.NoError(t, c.Close())
 	})
 
 	t.Run("clears_entries", func(t *testing.T) {
+		t.Parallel()
 		ctx := context.Background()
 		c := oncecache.New[int, int](fetchDouble)
 		_, _ = c.Get(ctx, 1)
@@ -705,7 +710,9 @@ func TestClose(t *testing.T) {
 		require.Equal(t, 0, c.Len())
 	})
 
-	t.Run("detaches_callbacks", func(t *testing.T) {
+	// Close does NOT fire OnEvict for the entries it clears.
+	t.Run("no_evict_on_close", func(t *testing.T) {
+		t.Parallel()
 		ctx := context.Background()
 		var evicts atomic.Int64
 		c := oncecache.New[int, int](
@@ -716,11 +723,35 @@ func TestClose(t *testing.T) {
 		)
 		_, _ = c.Get(ctx, 1)
 		require.NoError(t, c.Close())
-		// OnEvict is not invoked by Close.
-		require.Equal(t, int64(0), evicts.Load())
-		// And after Close, Delete also doesn't fire OnEvict (callbacks detached).
-		c.Delete(ctx, 1)
-		require.Equal(t, int64(0), evicts.Load())
+		require.Equal(t, int64(0), evicts.Load(),
+			"Close must not fire OnEvict for the entries it clears")
+	})
+
+	// Callbacks survive Close: re-using the cache after Close still fires
+	// callbacks as normal. Close only clears entries; it does not detach
+	// callbacks.
+	t.Run("callbacks_survive_close", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+		var fills, evicts atomic.Int64
+		c := oncecache.New[int, int](
+			fetchDouble,
+			oncecache.OnFill(func(_ context.Context, _, _ int, _ error) {
+				fills.Add(1)
+			}),
+			oncecache.OnEvict(func(_ context.Context, _, _ int, _ error) {
+				evicts.Add(1)
+			}),
+		)
+		_, _ = c.Get(ctx, 1) // fill
+		require.Equal(t, int64(1), fills.Load())
+		require.NoError(t, c.Close())
+
+		// After Close: refill and delete — both callbacks still fire.
+		_, _ = c.Get(ctx, 2)
+		require.Equal(t, int64(2), fills.Load())
+		c.Delete(ctx, 2)
+		require.Equal(t, int64(1), evicts.Load())
 	})
 }
 
@@ -759,7 +790,7 @@ func TestOnMiss(t *testing.T) {
 	var mu sync.Mutex
 	c := oncecache.New[int, int](
 		fetchDouble,
-		oncecache.OnMiss(func(_ context.Context, k int, _ int, _ error) {
+		oncecache.OnMiss(func(_ context.Context, k, _ int, _ error) {
 			mu.Lock()
 			missKeys = append(missKeys, k)
 			mu.Unlock()
@@ -853,7 +884,7 @@ func TestFetchPanic(t *testing.T) {
 			fetchCalls.Add(1)
 			panic("boom")
 		},
-		oncecache.OnMiss(func(_ context.Context, _ int, _ int, _ error) {
+		oncecache.OnMiss(func(_ context.Context, _, _ int, _ error) {
 			missCalls.Add(1)
 		}),
 		oncecache.OnFill(func(_ context.Context, _, _ int, _ error) {
@@ -891,19 +922,27 @@ func TestGob_Empty(t *testing.T) {
 	require.Equal(t, "empty", c2.Name())
 }
 
-// gobErr is a gob-registerable error type used by [TestGob_PreservesError].
-type gobErr string
+// gobError is a gob-registerable error type used by
+// [TestGob_PreservesError].
+type gobError string
 
-func (e gobErr) Error() string { return string(e) }
+func (e gobError) Error() string { return string(e) }
 
-func init() { gob.Register(gobErr("")) }
+// registerGobErrorOnce registers gobError with gob exactly once across all
+// tests, even if multiple tests use it. This avoids an init() func (which
+// the linter forbids) while also avoiding double-registration across
+// parallel tests.
+var registerGobErrorOnce sync.Once
+
+func registerGobError() { registerGobErrorOnce.Do(func() { gob.Register(gobError("")) }) }
 
 // TestGob_PreservesError verifies that fill errors survive gob round-trip.
 func TestGob_PreservesError(t *testing.T) {
 	t.Parallel()
+	registerGobError()
 	ctx := context.Background()
 
-	myErr := gobErr("boom")
+	myErr := gobError("boom")
 	c1 := oncecache.New[int, int](
 		func(_ context.Context, k int) (int, error) {
 			if k == 0 {
@@ -1101,7 +1140,8 @@ func TestEvent_Ctx(t *testing.T) {
 
 // TestConcurrentCloseAndGet verifies that Close races safely against Get.
 // With Close simplified to just clear entries (not detach callbacks), the
-// race detector should stay quiet.
+// race detector should stay quiet. Post-race, every remaining entry's
+// value must match the fetchDouble contract — detecting any torn read.
 func TestConcurrentCloseAndGet(t *testing.T) {
 	t.Parallel()
 
@@ -1112,7 +1152,9 @@ func TestConcurrentCloseAndGet(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		for i := 0; i < iters; i++ {
-			_, _ = c.Get(context.Background(), i)
+			v, err := c.Get(context.Background(), i)
+			require.NoError(t, err)
+			require.Equal(t, i*2, v, "value invariant must hold under concurrent Close")
 		}
 	}()
 	go func() {
@@ -1177,7 +1219,7 @@ func TestDelete_Reentry(t *testing.T) {
 	var c *oncecache.Cache[int, int]
 	c = oncecache.New[int, int](
 		fetchDouble,
-		oncecache.OnEvict(func(_ context.Context, k int, _ int, _ error) {
+		oncecache.OnEvict(func(_ context.Context, k, _ int, _ error) {
 			// Touch the cache from inside the eviction callback. With the
 			// pre-fix code that held c.mu across callbacks, all of these
 			// would deadlock.
@@ -1406,6 +1448,7 @@ func TestEntry_LogValue_Types(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("int_logged", func(t *testing.T) {
+		t.Parallel()
 		buf, log := newBufLogger()
 		c := oncecache.New[int, int](
 			fetchDouble,
@@ -1417,9 +1460,10 @@ func TestEntry_LogValue_Types(t *testing.T) {
 	})
 
 	t.Run("string_not_logged", func(t *testing.T) {
+		t.Parallel()
 		buf, log := newBufLogger()
 		c := oncecache.New[int, string](
-			func(_ context.Context, k int) (string, error) { return "secret", nil },
+			func(_ context.Context, _ int) (string, error) { return "secret", nil },
 			oncecache.Name("strs"),
 			oncecache.Log(log, slog.LevelInfo, oncecache.OpFill),
 		)
@@ -1429,9 +1473,10 @@ func TestEntry_LogValue_Types(t *testing.T) {
 	})
 
 	t.Run("logvaluer_logged", func(t *testing.T) {
+		t.Parallel()
 		buf, log := newBufLogger()
 		c := oncecache.New[int, hasLogValue](
-			func(_ context.Context, k int) (hasLogValue, error) {
+			func(_ context.Context, _ int) (hasLogValue, error) {
 				return hasLogValue{tag: "TAGGED"}, nil
 			},
 			oncecache.Name("lv"),
@@ -1442,9 +1487,10 @@ func TestEntry_LogValue_Types(t *testing.T) {
 	})
 
 	t.Run("struct_not_logged", func(t *testing.T) {
+		t.Parallel()
 		buf, log := newBufLogger()
 		c := oncecache.New[int, plainStruct](
-			func(_ context.Context, k int) (plainStruct, error) {
+			func(_ context.Context, _ int) (plainStruct, error) {
 				return plainStruct{secret: "nope"}, nil
 			},
 			oncecache.Name("ps"),
@@ -1535,7 +1581,7 @@ func TestCache_AsSlogAttribute(t *testing.T) {
 	t.Parallel()
 	buf, log := newBufLogger()
 	c := oncecache.New[int, string](
-		func(_ context.Context, k int) (string, error) { return "v", nil },
+		func(_ context.Context, _ int) (string, error) { return "v", nil },
 		oncecache.Name("attr-cache"),
 	)
 	_, _ = c.Get(context.Background(), 1)
@@ -1549,9 +1595,11 @@ func TestCache_AsSlogAttribute(t *testing.T) {
 }
 
 // TestStress runs random concurrent Get/MaybeSet/Delete/Clear/Has/Keys
-// operations against the cache for a fixed duration. Its job is to
-// surface races, deadlocks, and panics that targeted tests may miss.
-// Run with -race to be useful.
+// operations against the cache. Its primary job is to surface races,
+// deadlocks, and panics under -race. A Get or MaybeSet for any key k
+// produces a value that is either fetchDouble(k) = k*2 or the MaybeSet
+// value k*10 — any other observed value is a torn read and fails the
+// test invariant.
 func TestStress(t *testing.T) {
 	t.Parallel()
 	const goroutines = 32
@@ -1569,10 +1617,16 @@ func TestStress(t *testing.T) {
 		oncecache.OnHit(func(_ context.Context, _, _ int, _ error) {}),
 	)
 
+	checkValue := func(key, val int) {
+		if val != key*2 && val != key*10 {
+			t.Errorf("torn read: key=%d got val=%d (expected %d or %d)",
+				key, val, key*2, key*10)
+		}
+	}
+
 	wg := &sync.WaitGroup{}
 	wg.Add(goroutines)
 	for g := 0; g < goroutines; g++ {
-		g := g
 		go func() {
 			defer wg.Done()
 			rng := rand.New(rand.NewSource(int64(g)))
@@ -1581,7 +1635,10 @@ func TestStress(t *testing.T) {
 				key := rng.Intn(keyspace)
 				switch rng.Intn(6) {
 				case 0:
-					_, _ = c.Get(ctx, key)
+					v, err := c.Get(ctx, key)
+					if err == nil {
+						checkValue(key, v)
+					}
 				case 1:
 					_ = c.MaybeSet(ctx, key, key*10, nil)
 				case 2:

--- a/oncecache_test.go
+++ b/oncecache_test.go
@@ -1753,6 +1753,160 @@ func BenchmarkGet_Parallel_Hit(b *testing.B) {
 	})
 }
 
+// BenchmarkGet_Parallel_Miss measures concurrent cache misses across
+// unique keys — each call creates a new entry and invokes fetch exactly
+// once. Contrast with [BenchmarkGet_Parallel_Hit]: this one exercises the
+// map-insertion path under contention.
+func BenchmarkGet_Parallel_Miss(b *testing.B) {
+	ctx := context.Background()
+	c := oncecache.New[int, int](fetchDouble)
+	var key atomic.Int64
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_, _ = c.Get(ctx, int(key.Add(1)))
+		}
+	})
+}
+
+// BenchmarkGet_Hit_WithCallbacks measures the "slow path" hit cost when
+// all four callback kinds are registered. Compare to [BenchmarkGet_Hit]
+// for the callback-dispatch overhead.
+func BenchmarkGet_Hit_WithCallbacks(b *testing.B) {
+	noop4 := func(_ context.Context, _, _ int, _ error) {}
+	c := oncecache.New[int, int](
+		fetchDouble,
+		oncecache.OnHit(noop4),
+		oncecache.OnMiss(noop4),
+		oncecache.OnFill(noop4),
+		oncecache.OnEvict(noop4),
+	)
+	ctx := context.Background()
+	_, _ = c.Get(ctx, 42)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = c.Get(ctx, 42)
+	}
+}
+
+// BenchmarkGet_Miss_WithCallbacks measures the slow-path miss cost. Compare
+// to [BenchmarkGet_Miss] for the callback-dispatch overhead on miss.
+func BenchmarkGet_Miss_WithCallbacks(b *testing.B) {
+	noop4 := func(_ context.Context, _, _ int, _ error) {}
+	c := oncecache.New[int, int](
+		fetchDouble,
+		oncecache.OnHit(noop4),
+		oncecache.OnMiss(noop4),
+		oncecache.OnFill(noop4),
+	)
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = c.Get(ctx, i)
+	}
+}
+
+// BenchmarkGet_Miss_Panic measures the per-miss overhead when fetch
+// panics and the panic is recovered into a wrapped [oncecache.ErrPanic].
+// Compare to [BenchmarkGet_Miss] to isolate the recover/wrap cost.
+func BenchmarkGet_Miss_Panic(b *testing.B) {
+	c := oncecache.New[int, int](
+		func(_ context.Context, _ int) (int, error) { panic("bench-panic") },
+	)
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = c.Get(ctx, i)
+	}
+}
+
+// BenchmarkMaybeSet_Existing measures MaybeSet on an already-filled
+// entry — the common case in composite-cache propagation where the same
+// value is offered repeatedly. The call returns false without writing.
+func BenchmarkMaybeSet_Existing(b *testing.B) {
+	c := oncecache.New[int, int](fetchDouble)
+	ctx := context.Background()
+	c.MaybeSet(ctx, 42, 84, nil)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = c.MaybeSet(ctx, 42, 84, nil)
+	}
+}
+
+// BenchmarkDelete measures the Get+Delete cycle without an OnEvict
+// callback (fast path: no snapshot, no callback invocation).
+func BenchmarkDelete(b *testing.B) {
+	ctx := context.Background()
+	c := oncecache.New[int, int](fetchDouble)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = c.Get(ctx, i)
+		c.Delete(ctx, i)
+	}
+}
+
+// BenchmarkDelete_WithCallback measures the Get+Delete cycle with an
+// OnEvict callback, exercising the snapshot-then-invoke-outside-lock
+// path added in the Delete/Clear concurrency fix. Compare to
+// [BenchmarkDelete] for the callback-path overhead.
+func BenchmarkDelete_WithCallback(b *testing.B) {
+	ctx := context.Background()
+	c := oncecache.New[int, int](
+		fetchDouble,
+		oncecache.OnEvict(func(_ context.Context, _, _ int, _ error) {}),
+	)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = c.Get(ctx, i)
+		c.Delete(ctx, i)
+	}
+}
+
+// BenchmarkHas measures the cheap presence check on an existing key.
+func BenchmarkHas(b *testing.B) {
+	c := oncecache.New[int, int](fetchDouble)
+	_, _ = c.Get(context.Background(), 42)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = c.Has(42)
+	}
+}
+
+// BenchmarkOnEvent_NonBlocking measures the per-hit overhead of emitting
+// an [OnEvent] on a saturated (unbuffered, no receiver) channel with
+// block=false — every event is dropped. Baseline for event-system cost.
+func BenchmarkOnEvent_NonBlocking(b *testing.B) {
+	ctx := context.Background()
+	ch := make(chan oncecache.Event[int, int]) // unbuffered, no reader
+	c := oncecache.New[int, int](
+		fetchDouble,
+		oncecache.OnEvent(ch, false, oncecache.OpHit),
+	)
+	_, _ = c.Get(ctx, 42) // prime
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = c.Get(ctx, 42)
+	}
+}
+
 //nolint:revive
 func ExampleCache_Keys() {
 	// Ignore error handling for brevity.

--- a/opt.go
+++ b/opt.go
@@ -5,41 +5,25 @@ package oncecache
 // implementations.
 //
 // Opt is a closed interface: third-party packages cannot implement it
-// (the marker method is unexported). This keeps the dispatch in
-// (*Cache).applyOpts total: every Opt is one of the built-in kinds and
-// can be handled exhaustively.
+// (the marker method is unexported). This lets (*Cache).applyOpts dispatch
+// exhaustively over the built-in opt kinds without an "unknown Opt" escape
+// hatch leaking into the public API.
 type Opt interface {
 	// optioner is an unexported marker method that closes the Opt
-	// interface. It also unifies the two internal applier kinds
-	// (optApplier and concreteOptApplier) under a single parent.
+	// interface.
 	optioner()
 }
 
 // optApplier is the internal [Opt] variant whose apply method touches the
-// parameterized fields of [Cache]. Used by opts that need access to K/V
-// (callbacks, event channels).
+// parameterized fields of [Cache]. Used by [OnFill], [OnEvict], [OnHit],
+// [OnMiss], and [OnEvent] — opts that need access to K/V to manipulate
+// per-cache callback slices or event channels. Non-parameterized opts
+// ([Name], [Log]) bypass this interface and are dispatched directly by
+// applyOpts.
 type optApplier[K comparable, V any] interface {
 	Opt
 	apply(c *Cache[K, V])
 }
-
-// concreteOptApplier is the internal [Opt] variant for opts that only
-// configure non-parameterized fields — i.e., they can be written without
-// spelling out K and V. Used by [Name].
-type concreteOptApplier interface {
-	Opt
-	applyConcrete(c *concreteCache)
-}
-
-// concreteCache is a view over the non-parameterized state of [Cache]. It
-// is passed to concreteOptApplier.applyConcrete and holds pointers so
-// options can write through without the cache exposing its private fields
-// directly.
-type concreteCache struct {
-	name *string
-}
-
-var _ concreteOptApplier = (*Name)(nil)
 
 // Name is an [Opt] for [New] that sets the cache's display name, accessible
 // via [Cache.Name] and used by [Cache.String] and [Cache.LogValue] for
@@ -51,11 +35,6 @@ var _ concreteOptApplier = (*Name)(nil)
 // If [Name] is not specified, a random name like "cache-38a2b7d4" is
 // generated so every cache has a distinct identifier in logs.
 type Name string
-
-// applyConcrete writes the [Name] through the concreteCache view.
-func (o Name) applyConcrete(c *concreteCache) {
-	*c.name = string(o)
-}
 
 // optioner satisfies the [Opt] marker interface.
 func (o Name) optioner() {}

--- a/opt.go
+++ b/opt.go
@@ -1,46 +1,61 @@
 package oncecache
 
-// Opt is an option for [New].
+// Opt is a functional option accepted by [New]. See [Name], [OnFill],
+// [OnEvict], [OnHit], [OnMiss], [OnEvent], and [Log] for the built-in
+// implementations.
+//
+// Opt is a closed interface: third-party packages cannot implement it
+// (the marker method is unexported). This keeps the dispatch in
+// (*Cache).applyOpts total: every Opt is one of the built-in kinds and
+// can be handled exhaustively.
 type Opt interface {
-	// optioner is a marker method to unify our two functional option types,
-	// optApplier and concreteOptApplier.
+	// optioner is an unexported marker method that closes the Opt
+	// interface. It also unifies the two internal applier kinds
+	// (optApplier and concreteOptApplier) under a single parent.
 	optioner()
 }
 
-// optApplier is an [Opt] that uses the apply method to configure the fields of
-// [Cache]. It must be type-parameterized, as this Opt accesses the
-// parameterized fields of [Cache].
+// optApplier is the internal [Opt] variant whose apply method touches the
+// parameterized fields of [Cache]. Used by opts that need access to K/V
+// (callbacks, event channels).
 type optApplier[K comparable, V any] interface {
 	Opt
 	apply(c *Cache[K, V])
 }
 
-// concreteOptApplier is an [Opt] type that uses the applyConcrete method to
-// configure the non-parameterized (concrete) fields of [Cache].
+// concreteOptApplier is the internal [Opt] variant for opts that only
+// configure non-parameterized fields — i.e., they can be written without
+// spelling out K and V. Used by [Name].
 type concreteOptApplier interface {
 	Opt
 	applyConcrete(c *concreteCache)
 }
 
-// concreteCache contains pointers to the non-parameterized (concrete) state of
-// [Cache]. It is passed to concreteOptApplier.applyConcrete by [New].
+// concreteCache is a view over the non-parameterized state of [Cache]. It
+// is passed to concreteOptApplier.applyConcrete and holds pointers so
+// options can write through without the cache exposing its private fields
+// directly.
 type concreteCache struct {
 	name *string
 }
 
 var _ concreteOptApplier = (*Name)(nil)
 
-// Name is an [Opt] for [New] that sets the cache's name. The name is accessible
-// via [Cache.Name].
+// Name is an [Opt] for [New] that sets the cache's display name, accessible
+// via [Cache.Name] and used by [Cache.String] and [Cache.LogValue] for
+// readable debug/log output. When the same cache instance is configured
+// with [Name] more than once, the last value wins.
 //
-//	c := oncecache.New[int, string](fetch, oncecache.Name("foobar"))
+//	c := oncecache.New[int, string](fetch, oncecache.Name("users"))
 //
-// The name is used by [Cache.String] and [Cache.LogValue]. If [Name] is not
-// specified, a random name such as "cache-38a2b7d4" is generated.
+// If [Name] is not specified, a random name like "cache-38a2b7d4" is
+// generated so every cache has a distinct identifier in logs.
 type Name string
 
+// applyConcrete writes the [Name] through the concreteCache view.
 func (o Name) applyConcrete(c *concreteCache) {
 	*c.name = string(o)
 }
 
+// optioner satisfies the [Opt] marker interface.
 func (o Name) optioner() {}


### PR DESCRIPTION
## Summary

Addresses all findings from an extensive code review of `oncecache`, plus follow-up feedback from a Copilot bot review and CI lint. Twelve commits total on this branch.

### Correctness / concurrency

- **Delete/Clear vs in-flight fetch race** — `Delete`, `Clear`, and `GobEncode` used to read `e.val`/`e.err` without synchronizing against the filling goroutine's writes. An `atomic.Bool filled` flag on `entry` now gates those reads; in-flight entries are skipped. Confirmed by `go test -race` regression tests.
- **Delete/Clear callback deadlock** — `c.mu` is no longer held across `OnEvict` callbacks. Both methods snapshot under lock, release, then invoke callbacks. Callbacks may now safely call back into the same cache. `TestDelete_Reentry` and `TestClear_Reentry` prove this.
- **Fetch panic wedged the entry** — a panicking `FetchFunc` left the entry permanently cached as zero with `nil` error, silently breaking the `OpMiss`→`OpFill` lifecycle. A new `callFetch` helper recovers the panic and stores it as an error wrapping the new exported `ErrPanic`; `OnFill` fires with the wrapped error; `Get` returns the error instead of propagating the panic. The recovered panic is stored as a formatted `string` (not `any`) so panic-filled entries remain gob-encodable.
- **`c.name` read race** — reads via `Name`/`String`/`LogValue` raced against `GobDecode` writes. `name` is now `atomic.Pointer[string]`.
- **Close race & simplification** — `Close` now only clears entries (doesn't detach callbacks). No more race with concurrent `Get` on callback slice reads. Docs and the `TestClose` subtests match the simplified contract (`no_evict_on_close` and `callbacks_survive_close`).
- **GobDecode on a zero `Cache`** — previously panicked on `c.entries[k] = ent` because the map was nil. `GobDecode` now lazy-initializes `entries`, so gob-decoding into `var c Cache[K, V]` is safe.

### API changes

- `OnMiss` signature standardized to `(ctx, K, V, err)` — `V` is now inferable (was `(ctx, K)` which forced explicit `[K, V]`). The val/err args are always zero.
- `Event` gains a `Ctx` field; `OnEvent` blocking sends honor `ctx.Done()` so a stalled consumer cannot hang the producer.
- New exported sentinel `ErrPanic` for `errors.Is` matching against fetch-panic fill errors.
- `applyOpts` simplified to a 3-case type switch (`concreteCache` / `concreteOptApplier` removed).
- `entry.cache` back-pointer dropped; fill helpers now take the cache as a parameter.

### Cleanups

- Nil-deref in `examples/hrsystem/cache.go` error path fixed.
- `log.go` forwards the triggering `ctx` to `slog.LogAttrs` (was `context.Background()`).
- `randomName` uses 4 bytes of `crypto/rand` directly (was 128 bytes → CRC-32).
- `isNil` uses a `reflect.Kind` switch instead of `defer/recover`.
- `maps.Clear` → `clear` builtin; dropped `golang.org/x/exp` dependency.
- Go module bumped from 1.21 → 1.22; removed the `op := op` loop-var shim.
- Default `ops` ordering aligned between `OnEvent` and `Log`.
- README example name aligned with the test it references.
- Inner-closure `ctx` shadow renamed to `cbCtx`.
- `.claude/` and `.idea/` local tooling added to `.gitignore`.

### Documentation

- Expanded godoc on **every** public symbol: `FetchFunc`, `New`, `Cache` (+ per-field docs), each method, `Entry`, `Event`, `Op` (+ constants), the four On* callbacks, `OnEvent`, `Log`, `LogConfig`, `Opt`, `Name`, `NewContext`, `FromContext`, `ErrPanic`.
- Fixed 4 broken `[Cache.Set]` godoc links (now `[Cache.MaybeSet]`).
- Package doc reorganized with sectioned headings: Model / Scope / Events and callbacks / Concurrency.
- Internal comments explain the opt-dispatch machinery, fast/slow path selection, and per-entry synchronization contract.
- Fixed stale docs flagged by Copilot: `Cache.Get` (no longer claims panic propagates), `OnEvict` (callbacks run after lock release, safe to re-enter), `OpMiss` (panic → wrapped-error fill, OpFill still fires).

### Tests

- **63 test functions + 12 benchmarks + 2 runnable examples**, all passing under `go test -race`.
- Main-package statement coverage: **92.1% → 97.3%**.
- New regression tests for the concurrency fixes: `TestConcurrentDeleteAndFetch`, `TestClearDuringFetch`, `TestDelete_Reentry`, `TestClear_Reentry`, `TestConcurrentCloseAndGet` (all assert invariants, not just absence of race).
- New tests for panic semantics (`TestFetchPanic`, `TestErrPanic_IsTarget`, `TestFetchPanic_MaybeSetIsNoop`, `TestOnFill_PanicPropagates`, `TestOnEvict_PanicPropagates`), callback behavior (`TestOnHit`, `TestOnMiss`, `TestOnHit_ErrorEntry`, `TestCallback_RegistrationOrder`), `Event.Ctx` propagation (`TestEvent_Ctx`, `TestOnEvent_BlockingCancellation`), gob round-trip with errors, nil-handling edge cases, `Op` formatting.
- `TestStress` runs 32 goroutines × 2000 random ops × 64 keys and asserts `val ∈ {k*2, k*10}` on every observed Get — catches torn reads even when the race detector doesn't.
- Internal tests (`oncecache_internal_test.go`) cover unreachable-from-outside branches (`applyOpts` panic on unknown Opt, `randomName` format, `isNil` across nine kinds, `uniq` degenerate inputs, `fillPanicError` format).

## Breaking changes

- `OnMiss` signature change — callers using `(ctx, K)` must update to `(ctx, K, V, err)`. The V/err args are always zero.
- Fetch panic no longer propagates to the `Get` caller — it's recovered into an error wrapping `ErrPanic`. Callers that recovered around `Get` must now check `err`.
- `Close` no longer nils callback slices. If callers relied on this for GC, they should drop their reference to the cache instead.
- `Event` struct layout changed (new `Ctx` field). Positional struct literals will fail to compile; named-field literals are unaffected.

New exported API: `ErrPanic` (var), `Event.Ctx` (field).

## Commits

- `9df4713` Fix Delete/Clear race; add tests; expand godoc
- `d5ced33` Address remaining review items (concurrency, API cleanup, style)
- `abae41c` Extend test coverage to 97.5%
- `2ec1cd5` Address review feedback: CI lint, stale docs, Copilot findings
- `662a643` TestStress: capture loop var for older golangci-lint revive
- `c849bd3` Gitignore Claude Code local tooling state
- `86570f8` Add targeted benchmarks for fast/slow paths and new behaviors
- `1239b11` Clarify README and package doc for current behavior
- `2443676` Address Copilot second-review findings (zero-cache GobDecode dispatch, *Name, nil entries, panic-filled gob round-trip)
- `da2afdd` fillPanicError gob registration via sync.Once
- `1ee9f17` Correct GobDecode and MaybeSet godoc per Copilot findings
- `675e465` Gitignore JetBrains .idea directory

## Test plan

- [x] `go test -race -count=1 ./...` — green on both packages
- [x] `go test -cover ./...` — 97.3% main package
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] `golangci-lint run` — CI (v1.56.2) green
- [x] 12 benchmarks covering fast/slow paths, parallel hit/miss, panic recovery, and callback overhead. `BenchmarkGet_Hit` steady at 14 ns/op, 0 allocs; full reference table in the `86570f8` commit message
- [ ] Human review of breaking-change items before merge
