### PR TITLE
Fix OnMiss-panic handling, flaky TestOnEventChan, and getEntry lock leak

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ go get github.com/neilotoole/oncecache
 
 ## Usage
 
+`oncecache` requires Go 1.26 or later.
+
 The basic theory of operation is that a [`oncecache.Cache`](https://pkg.go.dev/github.com/neilotoole/oncecache#Cache) is created with a
 function that returns the value corresponding to a key. When a key is requested
 from the cache, the cache checks if the value is already present. If not, the

--- a/README.md
+++ b/README.md
@@ -136,8 +136,8 @@ entry `(key, zero-value, err)` is still a fully-populated entry, and a
 subsequent `Get` for the same key returns that same error without reinvoking
 fetch, until the entry is explicitly evicted.
 
-If the fetch function **panics**, `oncecache` recovers the panic and stores it
-as an error wrapping the exported
+If the fetch function (or an `OnMiss` callback) **panics**, `oncecache`
+recovers the panic and stores it as an error wrapping the exported
 [`ErrPanic`](https://pkg.go.dev/github.com/neilotoole/oncecache#ErrPanic)
 sentinel. `Get` returns that wrapped error — the panic is *not* propagated
 to the caller. `OnFill` callbacks fire normally with the wrapped error.

--- a/event.go
+++ b/event.go
@@ -256,9 +256,9 @@ const (
 	// OpMiss indicates a cache miss: [Cache.Get] found no entry for the
 	// key and is about to invoke [FetchFunc]. OpMiss fires once per entry
 	// lifetime and is immediately followed by [OpFill] — including when
-	// [FetchFunc] panics, in which case the panic is recovered into an
-	// error wrapping [ErrPanic] and OpFill carries that error. See
-	// [FetchFunc].
+	// [FetchFunc] or an [OnMiss] callback panics, in which case the panic
+	// is recovered into an error wrapping [ErrPanic] and OpFill carries
+	// that error. See [FetchFunc] and [OnMiss].
 	OpMiss Op = 2
 
 	// OpFill indicates that a cache entry has been populated. It is

--- a/event.go
+++ b/event.go
@@ -230,6 +230,12 @@ func OnHit[K comparable, V any](fn func(ctx context.Context, key K, val V, err e
 // OnMiss callbacks run synchronously; the triggering [Cache.Get] blocks
 // until they return. Prefer [OnEvent] for long-running work.
 //
+// If an OnMiss callback panics, the panic is recovered and becomes the
+// entry's fill error (wrapping [ErrPanic]), exactly as a [FetchFunc] panic
+// would; fetch is skipped, [OpFill] still fires with the wrapped error, and
+// the triggering [Cache.Get] returns (zero, wrapped error) rather than
+// propagating the panic.
+//
 // OnMiss is not emitted by [Cache.MaybeSet], since MaybeSet is not a
 // [Cache.Get] miss path.
 func OnMiss[K comparable, V any](fn func(ctx context.Context, key K, val V, err error)) Opt {

--- a/event.go
+++ b/event.go
@@ -254,11 +254,12 @@ const (
 	OpHit Op = 1
 
 	// OpMiss indicates a cache miss: [Cache.Get] found no entry for the
-	// key and is about to invoke [FetchFunc]. OpMiss fires once per entry
-	// lifetime and is immediately followed by [OpFill] — including when
-	// [FetchFunc] or an [OnMiss] callback panics, in which case the panic
-	// is recovered into an error wrapping [ErrPanic] and OpFill carries
-	// that error. See [FetchFunc] and [OnMiss].
+	// key and is about to fill it, normally by invoking [FetchFunc]. OpMiss
+	// fires once per entry lifetime and is immediately followed by [OpFill]
+	// — including when [FetchFunc] or an [OnMiss] callback panics, in which
+	// case the panic is recovered into an error wrapping [ErrPanic] and
+	// OpFill carries that error (when an OnMiss callback panics, fetch is
+	// skipped). See [FetchFunc] and [OnMiss].
 	OpMiss Op = 2
 
 	// OpFill indicates that a cache entry has been populated. It is

--- a/oncecache.go
+++ b/oncecache.go
@@ -437,10 +437,11 @@ func (c *Cache[K, V]) MaybeSet(ctx context.Context, key K, val V, err error) (ok
 // Concurrent Get calls for the same unfilled key block until the in-flight
 // fetch completes and then all receive the same (val, err).
 //
-// If fetch panics, the panic is recovered and converted into a fill error
-// wrapping [ErrPanic]; Get returns (zero, that wrapped error) instead of
-// propagating the panic. [OpFill] still fires with the wrapped error. See
-// [FetchFunc] for details.
+// If fetch (or an [OnMiss] callback) panics, the panic is recovered and
+// converted into a fill error wrapping [ErrPanic]; Get returns (zero, that
+// wrapped error) instead of propagating the panic. When an OnMiss callback
+// panics, fetch is skipped. [OpFill] still fires with the wrapped error in
+// either case. See [FetchFunc] and [OnMiss] for details.
 func (c *Cache[K, V]) Get(ctx context.Context, key K) (V, error) {
 	e := c.getEntry(key)
 	return c.getValueFn(ctx, c, e, key)

--- a/oncecache.go
+++ b/oncecache.go
@@ -451,13 +451,16 @@ func (c *Cache[K, V]) Get(ctx context.Context, key K) (V, error) {
 // caller's once.Do completes. Holds c.mu only for the map lookup/insert.
 func (c *Cache[K, V]) getEntry(key K) *entry[K, V] {
 	c.mu.Lock()
-	defer c.mu.Unlock()
-	e, ok := c.entries[key]
-	if ok {
+	if e, ok := c.entries[key]; ok {
+		// Hit (the hot path): explicit unlock, no defer overhead.
+		c.mu.Unlock()
 		return e
 	}
 
-	e = &entry[K, V]{}
+	// Miss: defer the unlock so a panic on the nil-map write — reachable
+	// only on an unsupported zero-value Cache — cannot leak c.mu.
+	defer c.mu.Unlock()
+	e := &entry[K, V]{}
 	c.entries[key] = e
 	return e
 }

--- a/oncecache.go
+++ b/oncecache.go
@@ -93,13 +93,14 @@ import (
 // invariant: a miss is followed by a fill — successful or panic-wrapped.
 type FetchFunc[K comparable, V any] func(ctx context.Context, key K) (val V, err error)
 
-// ErrPanic is the sentinel wrapped in the fill error when a [FetchFunc]
-// panics. Use [errors.Is] to detect it:
+// ErrPanic is the sentinel wrapped in the fill error when a [FetchFunc] (or
+// an [OnMiss] callback) panics during a [Cache.Get] fill. Use [errors.Is] to
+// detect it:
 //
 //	if _, err := c.Get(ctx, key); errors.Is(err, oncecache.ErrPanic) {
-//		// ... handle panic-during-fetch
+//		// ... handle panic-during-fill
 //	}
-var ErrPanic = errors.New("oncecache: panic in FetchFunc")
+var ErrPanic = errors.New("oncecache: panic during fill")
 
 // New constructs a [Cache] parameterized over key type K and value type V. The
 // fetch func is invoked on-demand by [Cache.Get] to populate an entry for a
@@ -256,8 +257,18 @@ type Cache[K comparable, V any] struct {
 // is set via the [Name] opt to [New]; otherwise a random name of the form
 // "cache-XXXXXXXX" (eight hex digits) is generated. Safe for concurrent
 // use, including with [Cache.GobDecode].
+//
+// Name returns "" for a nil receiver or an uninitialized (zero-value) Cache,
+// so it is safe to call on the zero [Event]/[Entry] values that [slog] may
+// resolve (see [Event.LogValue]).
 func (c *Cache[K, V]) Name() string {
-	return *c.name.Load()
+	if c == nil {
+		return ""
+	}
+	if p := c.name.Load(); p != nil {
+		return *p
+	}
+	return ""
 }
 
 // Len returns the number of entries in the cache, including entries that
@@ -440,15 +451,14 @@ func (c *Cache[K, V]) Get(ctx context.Context, key K) (V, error) {
 // caller's once.Do completes. Holds c.mu only for the map lookup/insert.
 func (c *Cache[K, V]) getEntry(key K) *entry[K, V] {
 	c.mu.Lock()
+	defer c.mu.Unlock()
 	e, ok := c.entries[key]
 	if ok {
-		c.mu.Unlock()
 		return e
 	}
 
 	e = &entry[K, V]{}
 	c.entries[key] = e
-	c.mu.Unlock()
 	return e
 }
 
@@ -652,8 +662,11 @@ func registerFillPanicErrorOnGob() {
 // returning the wrapped error is more useful than propagating the panic to
 // the caller, and it avoids leaving the entry in a half-initialized state.
 //
-// Callback panics (OnMiss, OnFill, OnHit, OnEvict) are deliberately not
-// recovered here; they propagate to the triggering caller.
+// Panics in OnFill, OnHit, and OnEvict callbacks are deliberately not
+// recovered; they propagate to the triggering caller. OnMiss is the
+// exception: because it runs inside the entry's sync.Once before fetch, an
+// unrecovered panic there would consume the Once and strand the entry
+// unfilled, so callOnMiss recovers it into a fill error instead.
 func callFetch[K comparable, V any](ctx context.Context, c *Cache[K, V], key K) (val V, err error) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -663,6 +676,29 @@ func callFetch[K comparable, V any](ctx context.Context, c *Cache[K, V], key K) 
 		}
 	}()
 	return c.fetch(ctx, key)
+}
+
+// callOnMiss invokes the OnMiss callbacks, recovering any panic and
+// converting it into an error wrapping [ErrPanic] (mirroring [callFetch]).
+// A non-nil return means an OnMiss callback panicked; the caller stores that
+// error as the entry's fill result and skips fetch, so the entry ends up
+// filled with a panic-wrapped error rather than stranded unfilled. The
+// callbacks receive the zero value and a nil error, since the entry is not
+// yet populated at miss time.
+func callOnMiss[K comparable, V any](ctx context.Context, c *Cache[K, V], key K) (err error) {
+	if len(c.onMiss) == 0 {
+		return nil
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = &fillPanicError{recovered: fmt.Sprintf("%v", r)}
+		}
+	}()
+	var zero V
+	for _, fn := range c.onMiss {
+		fn(ctx, key, zero, nil)
+	}
+	return nil
 }
 
 // maybeSetValueSlow is the MaybeSet core used when OnFill callbacks are
@@ -705,16 +741,21 @@ func maybeSetValueFast[K comparable, V any](
 // all inside the entry's sync.Once. On hit it fires OnHit outside the Once
 // (safe: the Once's completion synchronizes the val/err writes for later
 // readers).
+//
+// A panic in an OnMiss callback is recovered and becomes the entry's fill
+// error (wrapping [ErrPanic]), exactly as a fetch panic would; fetch is
+// skipped in that case but [OnFill] still fires with the wrapped error.
 func getValueSlow[K comparable, V any](ctx context.Context, c *Cache[K, V], e *entry[K, V], key K) (V, error) {
 	var miss bool
 	e.once.Do(func() {
 		miss = true
 		cbCtx := NewContext(ctx, c)
-		for _, fn := range c.onMiss {
-			fn(cbCtx, key, e.val, e.err)
-		}
 
-		e.val, e.err = callFetch(cbCtx, c, key)
+		if err := callOnMiss(cbCtx, c, key); err != nil {
+			e.err = err // e.val stays the zero value; fetch is skipped.
+		} else {
+			e.val, e.err = callFetch(cbCtx, c, key)
+		}
 		e.filled.Store(true)
 
 		for _, fn := range c.onFill {

--- a/oncecache_test.go
+++ b/oncecache_test.go
@@ -1438,9 +1438,10 @@ func TestOnHit_ErrorEntry(t *testing.T) {
 	require.Equal(t, int64(1), hits.Load())
 }
 
-// TestOnFill_PanicPropagates verifies that callback panics are NOT
-// recovered (only fetch panics are). The panic propagates to the Get
-// caller, but the entry is still filled, so subsequent Gets succeed.
+// TestOnFill_PanicPropagates verifies that an OnFill panic propagates to
+// the Get caller and is NOT recovered (only FetchFunc and OnMiss panics are
+// recovered into a fill error). The entry is still filled before OnFill
+// runs, so subsequent Gets succeed.
 func TestOnFill_PanicPropagates(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/oncecache_test.go
+++ b/oncecache_test.go
@@ -444,10 +444,6 @@ func TestOnEventChan(t *testing.T) {
 						empCache.Delete(ctx, emp.ID)
 					}
 				default:
-					if event.Op.IsZero() {
-						// This is the final zero event, indicating that the channel is closed.
-						return
-					}
 					panic(fmt.Sprintf("unexpected action: %v", event.Op))
 				}
 				actionCh <- event.Op

--- a/oncecache_test.go
+++ b/oncecache_test.go
@@ -369,7 +369,13 @@ func TestCallbacks(t *testing.T) {
 func TestOnEventChan(t *testing.T) {
 	log := slogt.New(t)
 	ctx, cancelFn := context.WithCancel(context.Background())
-	defer cancelFn()
+	var wg sync.WaitGroup
+	// Cancel the consumer goroutine and wait for it to exit before the test
+	// returns, so it cannot log a (zero-value) event after completion.
+	defer func() {
+		cancelFn()
+		wg.Wait()
+	}()
 
 	db := loadHRDatabase(t)
 
@@ -380,7 +386,6 @@ func TestOnEventChan(t *testing.T) {
 	)
 
 	orgCacheCh := make(chan oncecache.Event[string, *hrsystem.Org], 10)
-	defer close(orgCacheCh)
 
 	orgCache = oncecache.New[string, *hrsystem.Org](
 		db.GetOrg,
@@ -390,7 +395,6 @@ func TestOnEventChan(t *testing.T) {
 	)
 
 	deptCacheCh := make(chan oncecache.Event[string, *hrsystem.Department], 10)
-	defer close(deptCacheCh)
 
 	deptCache = oncecache.New[string, *hrsystem.Department](
 		db.GetDepartment,
@@ -403,7 +407,9 @@ func TestOnEventChan(t *testing.T) {
 
 	// We use actionCh to signal that an event has been handled.
 	actionCh := make(chan oncecache.Op, 100)
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		log2 := log.With("layer", "event")
 		for {
 			select {
@@ -906,6 +912,52 @@ func TestFetchPanic(t *testing.T) {
 	require.Zero(t, v)
 	require.ErrorIs(t, err, oncecache.ErrPanic)
 	require.Equal(t, int64(1), fetchCalls.Load())
+}
+
+// TestOnMissPanic verifies that a panic in an OnMiss callback is recovered
+// into the entry's fill error (wrapping ErrPanic) rather than propagating or
+// stranding the entry unfilled: fetch is skipped, OnFill still fires with the
+// wrapped error, subsequent Gets return the same error, and the entry is
+// properly filled (so Delete fires OnEvict).
+func TestOnMissPanic(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	var fetchCalls, fillCalls, evictCalls atomic.Int64
+	c := oncecache.New[int, int](
+		func(_ context.Context, _ int) (int, error) {
+			fetchCalls.Add(1)
+			return 42, nil
+		},
+		oncecache.OnMiss(func(_ context.Context, _, _ int, _ error) {
+			panic("miss-boom")
+		}),
+		oncecache.OnFill(func(_ context.Context, _, _ int, _ error) {
+			fillCalls.Add(1)
+		}),
+		oncecache.OnEvict(func(_ context.Context, _, _ int, _ error) {
+			evictCalls.Add(1)
+		}),
+	)
+
+	// The triggering Get returns a wrapped error rather than propagating the panic.
+	v, err := c.Get(ctx, 1)
+	require.Zero(t, v)
+	require.ErrorIs(t, err, oncecache.ErrPanic)
+	require.Contains(t, err.Error(), "miss-boom")
+	require.Equal(t, int64(0), fetchCalls.Load(), "fetch must be skipped when OnMiss panics")
+	require.Equal(t, int64(1), fillCalls.Load(), "OpFill must still fire with the wrapped error")
+
+	// Subsequent Get returns the same wrapped error; the entry is not a zombie.
+	v, err = c.Get(ctx, 1)
+	require.Zero(t, v)
+	require.ErrorIs(t, err, oncecache.ErrPanic)
+	require.Equal(t, int64(0), fetchCalls.Load())
+
+	// The entry is properly filled, so Delete fires OnEvict.
+	c.Delete(ctx, 1)
+	require.Equal(t, int64(1), evictCalls.Load(),
+		"Delete must fire OnEvict for the filled (panic-errored) entry")
 }
 
 // TestGob_Empty verifies gob round-trip of an empty cache preserves the name.

--- a/oncecache_test.go
+++ b/oncecache_test.go
@@ -919,7 +919,11 @@ func TestOnMissPanic(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
+	// OnFill/OnEvict callbacks fire synchronously on the calling goroutine,
+	// so capturing their args in plain vars (read after the call) is race-free.
 	var fetchCalls, fillCalls, evictCalls atomic.Int64
+	var fillVal, evictVal int
+	var fillErr, evictErr error
 	c := oncecache.New[int, int](
 		func(_ context.Context, _ int) (int, error) {
 			fetchCalls.Add(1)
@@ -928,11 +932,13 @@ func TestOnMissPanic(t *testing.T) {
 		oncecache.OnMiss(func(_ context.Context, _, _ int, _ error) {
 			panic("miss-boom")
 		}),
-		oncecache.OnFill(func(_ context.Context, _, _ int, _ error) {
+		oncecache.OnFill(func(_ context.Context, _, val int, err error) {
 			fillCalls.Add(1)
+			fillVal, fillErr = val, err
 		}),
-		oncecache.OnEvict(func(_ context.Context, _, _ int, _ error) {
+		oncecache.OnEvict(func(_ context.Context, _, val int, err error) {
 			evictCalls.Add(1)
+			evictVal, evictErr = val, err
 		}),
 	)
 
@@ -942,7 +948,11 @@ func TestOnMissPanic(t *testing.T) {
 	require.ErrorIs(t, err, oncecache.ErrPanic)
 	require.Contains(t, err.Error(), "miss-boom")
 	require.Equal(t, int64(0), fetchCalls.Load(), "fetch must be skipped when OnMiss panics")
-	require.Equal(t, int64(1), fillCalls.Load(), "OpFill must still fire with the wrapped error")
+
+	// OnFill must fire once and receive the zero value plus the wrapped error.
+	require.Equal(t, int64(1), fillCalls.Load(), "OpFill must still fire")
+	require.Zero(t, fillVal, "OnFill must receive the zero value")
+	require.ErrorIs(t, fillErr, oncecache.ErrPanic, "OnFill must receive the wrapped ErrPanic")
 
 	// Subsequent Get returns the same wrapped error; the entry is not a zombie.
 	v, err = c.Get(ctx, 1)
@@ -950,10 +960,12 @@ func TestOnMissPanic(t *testing.T) {
 	require.ErrorIs(t, err, oncecache.ErrPanic)
 	require.Equal(t, int64(0), fetchCalls.Load())
 
-	// The entry is properly filled, so Delete fires OnEvict.
+	// The entry is properly filled, so Delete fires OnEvict with the same wrapped error.
 	c.Delete(ctx, 1)
 	require.Equal(t, int64(1), evictCalls.Load(),
 		"Delete must fire OnEvict for the filled (panic-errored) entry")
+	require.Zero(t, evictVal, "OnEvict must receive the zero value")
+	require.ErrorIs(t, evictErr, oncecache.ErrPanic, "OnEvict must receive the wrapped ErrPanic")
 }
 
 // TestGob_Empty verifies gob round-trip of an empty cache preserves the name.


### PR DESCRIPTION
Addresses three findings from a deep package review.

## 1. `OnMiss` callback panic no longer strands the entry (behavior change)

Previously, a panicking `OnMiss` callback consumed the entry's `sync.Once` *before* `filled` was set or `fetch` ran, leaving a "zombie" entry: every subsequent `Get` for that key silently returned `(zero, nil)` and never refetched, and `MaybeSet` couldn't repopulate it.

Now `callOnMiss` recovers an `OnMiss` panic into a fill error wrapping `ErrPanic` — exactly like a `FetchFunc` panic:
- fetch is skipped,
- the entry is marked `filled`,
- `OnFill` still fires with the wrapped error (preserving the `OpMiss`→`OpFill` lifecycle),
- the triggering `Get` returns `(zero, wrapped error)` instead of propagating the panic,
- subsequent `Get`s return the same error; `Delete` fires `OnEvict` normally.

`ErrPanic`'s message is generalized to `"oncecache: panic during fill"` since it now covers both fetch and `OnMiss` panics (identity unchanged; no test matched the string). Docs for `ErrPanic`, `OnMiss`, and the internal `callFetch`/`getValueSlow` updated. New test: `TestOnMissPanic`.

## 2. Flaky `TestOnEventChan`

The consumer goroutine outlived the test: the buffered channels were closed (via deferred `close`) *before* the context was cancelled, so the goroutine read zero-value `Event`s from the closed channels and logged them after the test returned — tripping `slogt`'s "log in goroutine after test completed" panic (reproducible with `-count`). 

- The test now cancels the context and **waits** (`sync.WaitGroup`) for the goroutine to exit before returning, and no longer closes the channels (the goroutine exits via `ctx.Done()`).
- Library hardening: `Cache.Name()` now returns `""` for a nil receiver / uninitialized cache, so `Event.LogValue` / `Entry.LogValue` / `String` can't panic on a zero `Event`/`Entry`.

## 3. `getEntry` mutex-leak safety

`getEntry` used explicit `c.mu.Unlock()`. On the (unsupported) zero-value `Cache` path, the nil-map write panics and skips the unlock, permanently leaking `c.mu` and deadlocking the cache if the panic is recovered. Switched to `defer c.mu.Unlock()`.

## Test plan

- [x] `go build ./...`, `go vet ./...` — clean
- [x] `go test -race -count=1 ./...` — green
- [x] `go test -run TestOnEventChan -race -count=50` — stable (was flaky)
- [x] `go test -run TestOnMissPanic` — passes
- [x] `golangci-lint run ./...` (v2.12.2) — 0 issues
- [x] coverage 96.7%