### PR TITLE
CI: run tests under -race -shuffle -count=1 and smoke-run benchmarks

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,4 +28,10 @@ jobs:
         version: ${{ env.GOLANGCI_LINT_VERSION }}
 
     - name: Test
-      run: go test -v ./...
+      run: go test -race -shuffle=on -count=1 -cover -v ./...
+
+    - name: Benchmarks (smoke)
+      # Run every benchmark once under -race to verify they execute (and the
+      # parallel ones stay race-free). Not a perf measurement: timings on
+      # shared CI runners are too noisy to be meaningful.
+      run: go test -race -run='^$' -bench=. -benchtime=1x ./...

--- a/oncecache_test.go
+++ b/oncecache_test.go
@@ -1654,6 +1654,20 @@ func TestCache_AsSlogAttribute(t *testing.T) {
 	require.Contains(t, out, "val=string")
 }
 
+// TestName_NilAndZeroValue verifies Cache.Name is safe to call on a nil
+// receiver and on an uninitialized (zero-value) cache, returning "" rather
+// than panicking — the property [Event.LogValue]/[Entry.LogValue] rely on
+// when slog resolves a zero Event/Entry.
+func TestName_NilAndZeroValue(t *testing.T) {
+	t.Parallel()
+
+	var nilCache *oncecache.Cache[int, int]
+	require.Equal(t, "", nilCache.Name(), "nil receiver must yield empty name")
+
+	var zeroCache oncecache.Cache[int, int]
+	require.Equal(t, "", zeroCache.Name(), "zero-value cache must yield empty name")
+}
+
 // TestStress runs random concurrent Get/MaybeSet/Delete/Clear/Has/Keys
 // operations against the cache. Its primary job is to surface races,
 // deadlocks, and panics under -race. A Get or MaybeSet for any key k


### PR DESCRIPTION
Makes CI exhaustive for this concurrency-critical cache. Previously the workflow ran a plain `go test -v ./...` — **no race detector**, and benchmarks were only compile-checked, never executed.

## Changes

`.github/workflows/go.yml`:
- **Test** step → `go test -race -shuffle=on -count=1 -cover -v ./...`
  - `-race` — data-race detection (the key gap; the cache relies on a `filled atomic.Bool`, per-entry `sync.Once`, lock-released callbacks, atomic `name`).
  - `-shuffle=on` — randomizes execution order to surface order-dependence.
  - `-count=1` — disables the test cache so tests always actually run.
  - `-cover` — prints coverage in the CI log.
- **Benchmarks (smoke)** step → `go test -race -run='^$' -bench=. -benchtime=1x ./...`
  - Runs every benchmark once under `-race` to verify it executes and the parallel ones stay race-free. Not a perf measurement — shared-runner timings are too noisy to track meaningfully.

`oncecache_test.go`:
- `TestName_NilAndZeroValue` covers `Cache.Name`'s nil-receiver and zero-value guards (added in the prior PR, previously untested). Main-package coverage **96.7% → 97.4%**.

## Coverage note

Main package is **97.4%**. The remaining uncovered statements are unreachable-by-design: the unexported `optioner()` marker methods (0% — never called; they exist only to make the `Opt` interface closed) and a couple of hard-to-trigger gob error paths. `examples/hrsystem` sits at 54.4% (illustrative example code).

## Test plan

- [x] `go test -race -shuffle=on -count=1 -cover ./...` — green, 97.4%
- [x] `go test -race -run='^$' -bench=. -benchtime=1x ./...` — all 12 benchmarks execute, race-clean
- [x] `golangci-lint run ./...` (v2.12.2) — 0 issues
- [ ] CI green with the new steps