### PR TITLE
CI: upload coverage to Codecov + add coverage badge

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,7 +28,17 @@ jobs:
         version: ${{ env.GOLANGCI_LINT_VERSION }}
 
     - name: Test
-      run: go test -race -shuffle=on -count=1 -cover -v ./...
+      run: go test -race -shuffle=on -count=1 -coverprofile=coverage.out -covermode=atomic -v ./...
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./coverage.out
+        slug: neilotoole/oncecache
+        # Don't fail the build on a Codecov upload hiccup (or before the
+        # CODECOV_TOKEN secret is configured).
+        fail_ci_if_error: false
 
     - name: Benchmarks (smoke)
       # Run every benchmark once under -race to verify they execute (and the

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Go Report Card](https://goreportcard.com/badge/neilotoole/oncecache)](https://goreportcard.com/report/neilotoole/oncecache)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/neilotoole/oncecache/blob/master/LICENSE)
 ![Workflow](https://github.com/neilotoole/oncecache/actions/workflows/go.yml/badge.svg)
+[![codecov](https://codecov.io/gh/neilotoole/oncecache/branch/master/graph/badge.svg)](https://codecov.io/gh/neilotoole/oncecache)
 
 `oncecache` is a strongly-typed, concurrency-safe, context-aware,
 dependency-free, in-memory, on-demand Golang object cache, focused on write-once,

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+# Codecov configuration. See https://docs.codecov.com/docs/codecov-yaml
+coverage:
+  status:
+    # Report coverage changes but never fail the PR check on a dip.
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+# The examples module is illustrative; exclude it from the coverage metric
+# so the badge reflects the library code.
+ignore:
+  - "examples"


### PR DESCRIPTION
Adds Codecov coverage reporting and a README badge. Coverage was previously only printed to the CI log; this uploads it so there's a badge, PR coverage comments, and trend tracking.

## Changes

`.github/workflows/go.yml`:
- Test step emits a profile: `-coverprofile=coverage.out -covermode=atomic` (atomic is the correct mode under `-race`).
- New **Upload coverage to Codecov** step (`codecov/codecov-action@v5`), gated by the `CODECOV_TOKEN` secret. `fail_ci_if_error: false` so an upload hiccup — or a missing token before it's configured — never reds CI.

`codecov.yml` (validated against Codecov's API — "Valid!"):
- `project`/`patch` status set to **informational** — coverage dips report but never fail the PR check.
- `examples` excluded from the metric, so the badge reflects the library code (~97.4%).

`README.md`: codecov badge added alongside the existing badges.

## Required one-time setup (outside the repo)

The upload needs two things only the repo owner can do:
1. Enable **neilotoole/oncecache** at https://codecov.io (sign in with GitHub, add the repo).
2. Add a **`CODECOV_TOKEN`** repository secret (Codecov → repo settings → copy the upload token → GitHub repo → Settings → Secrets and variables → Actions).

Until then, the upload step is a harmless no-op (CI stays green) and the badge shows "unknown".

## Test plan

- [x] `go test -race -shuffle=on -count=1 -coverprofile=coverage.out -covermode=atomic ./...` — green, profile generated (`mode: atomic`)
- [x] `codecov.yml` validated via `https://codecov.io/validate` — Valid!
- [x] `coverage.out` is gitignored (`*.out`) — not committed
- [x] `go build`, `golangci-lint run` — clean
- [ ] CI green with the upload step (no token yet → step skips/no-ops)