### PR TITLE
Bump slogt to v2.0.0

### DIFF
--- a/examples/hrsystem/hrsystem_test.go
+++ b/examples/hrsystem/hrsystem_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/neilotoole/slogt"
+	"github.com/neilotoole/slogt/v2"
 
 	"github.com/neilotoole/oncecache/examples/hrsystem"
 )

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/neilotoole/oncecache
 go 1.26
 
 require (
-	github.com/neilotoole/slogt v1.1.0
+	github.com/neilotoole/slogt/v2 v2.0.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/neilotoole/slogt v1.1.0 h1:c7qE92sq+V0yvCuaxph+RQ2jOKL61c4hqS1Bv9W7FZE=
-github.com/neilotoole/slogt v1.1.0/go.mod h1:RCrGXkPc/hYybNulqQrMHRtvlQ7F6NktNVLuLwk6V+w=
+github.com/neilotoole/slogt/v2 v2.0.0 h1:Kz8VWdkjXZnkVvN1hsGYI1ervWhlcDcIcVizUJbLbH8=
+github.com/neilotoole/slogt/v2 v2.0.0/go.mod h1:M/RN37tAuM3cpb/wD6lCpOSvphLMjuAzA/IV2hqJh3E=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=

--- a/oncecache_test.go
+++ b/oncecache_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/neilotoole/slogt"
+	"github.com/neilotoole/slogt/v2"
 
 	"github.com/neilotoole/oncecache"
 	"github.com/neilotoole/oncecache/examples/hrsystem"


### PR DESCRIPTION
Updates the test-only dependency `github.com/neilotoole/slogt` from `v1.1.0` to `v2.0.0`.

v2 uses Go's semantic import versioning, so the module path gains a `/v2` suffix. The only API used is `slogt.New(t)`, whose v2 signature `New(t testing.TB, opts ...Option) *slog.Logger` is call-compatible, so no call-site changes were needed.

## Changes
- `go.mod`/`go.sum`: `github.com/neilotoole/slogt v1.1.0` → `github.com/neilotoole/slogt/v2 v2.0.0` (v1 dropped by `go mod tidy`).
- Import path updated in the two test files that use it (`oncecache_test.go`, `examples/hrsystem/hrsystem_test.go`).

## Note
slogt v2 routes log output to `t.Output()` (added in Go 1.25) rather than `t.Log`; the module already requires `go 1.26`, so this is fine. The slogt-heavy `TestOnEventChan` was run ×30 under `-race` to confirm no regression.

## Test plan
- [x] `go build ./...`, `go vet ./...` — clean
- [x] `go test -race -shuffle=on -count=1 ./...` — green, coverage 97.4%
- [x] `go test -run TestOnEventChan -race -count=30 ./` — stable
- [x] `golangci-lint run ./...` (v2.12.2) — 0 issues
- [ ] CI green