### PR TITLE
Add Dependabot config (Go modules + GitHub Actions)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+# Dependabot configuration. See
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  # Go module dependencies (e.g. testify, slogt). These are test-only deps;
+  # the library itself is dependency-free.
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      # Batch routine minor/patch bumps into a single PR; major (potentially
+      # breaking) updates still open as separate, individually reviewable PRs.
+      go-modules:
+        update-types:
+          - minor
+          - patch
+
+  # GitHub Actions used by the workflows (actions/checkout, actions/setup-go,
+  # golangci/golangci-lint-action, codecov/codecov-action).
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
Adds `.github/dependabot.yml` so dependency and action updates are opened as PRs automatically.

## What it covers
- **`gomod`** — test-only Go deps (`testify`, `slogt`). The library itself is dependency-free.
- **`github-actions`** — the actions the Go workflow uses (`actions/checkout`, `actions/setup-go`, `golangci/golangci-lint-action`, `codecov/codecov-action`).

## Policy
- **Weekly** schedule, limit 5 open PRs per ecosystem.
- **Grouped** minor/patch bumps → one PR per ecosystem to reduce noise; **major** (potentially breaking) updates open as separate, individually reviewable PRs.

## Notes
- Config validated as well-formed YAML; GitHub validates the Dependabot schema once it lands on the default branch (visible under Insights → Dependency graph → Dependabot).
- No code change; the normal CI (build/test/lint) still runs on this PR.

This is what would have surfaced the next `testify` release without a manual check.