### PR TITLE
README: Go-requirement as a NOTE callout + intro polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ corresponding to a key is expensive to compute or fetch, the value is likely to 
 multiple times, and is not expected to change. The cache is not intended for general purpose
 caching where values are frequently updated.
 
+`oncecache` was created to support the [`sq`](https://github.com/neilotoole/sq) data-wrangling CLI.
 
 ## Install
 
@@ -27,9 +28,11 @@ Add to your `go.mod` via `go get`:
 go get github.com/neilotoole/oncecache
 ```
 
-## Usage
+> [!NOTE]
+> `oncecache` requires Go 1.26 or later.
 
-`oncecache` requires Go 1.26 or later.
+
+## Usage
 
 The basic theory of operation is that a [`oncecache.Cache`](https://pkg.go.dev/github.com/neilotoole/oncecache#Cache) is created with a
 function that returns the value corresponding to a key. When a key is requested


### PR DESCRIPTION
Docs-only polish to the README.

- The **"requires Go 1.26 or later"** line moves from the Usage section into the **Install** section and is now a GitHub `> [!NOTE]` callout, so it renders as a styled note next to the `go get` instructions.
- Adds a one-line intro noting `oncecache` was created to support the [sq](https://github.com/neilotoole/sq) CLI.

No code change.